### PR TITLE
ci: unblock Manual Publish for committed version bumps

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -67,7 +67,10 @@ jobs:
 
       - name: Update package.json version
         run: |
-          npm version ${{ inputs.version }} --no-git-tag-version
+          # --allow-same-version: the documented release flow commits the version
+          # bump to main first, so package.json may already be at inputs.version;
+          # without this flag `npm version` aborts with "Version not changed".
+          npm version ${{ inputs.version }} --no-git-tag-version --allow-same-version
           echo "Updated package.json to version ${{ inputs.version }}"
 
       - name: Verify package contents


### PR DESCRIPTION
## Why

The 0.3.0 release is blocked. The documented "Automated Release" flow commits the version bump to `main` first (PR #17 did this — `package.json` is now `0.3.0`). But the **Manual Publish** workflow — which is what actually publishes to npm — re-runs:

```
npm version <version> --no-git-tag-version
```

When `package.json` is already at that version, npm aborts with **"Version not changed"** (exit 1), so the publish never runs.

## Fix

Add `--allow-same-version` so the step is a harmless no-op when the bump is already committed, while still working for a fresh version (hotfix dispatch).

One-line, workflow-only change. After merge, dispatching Manual Publish (v0.3.0) publishes to npm with provenance, tags `v0.3.0`, and creates the GitHub Release + docs deploy.