### PR TITLE
ci: unblock Manual Publish checkout (use GITHUB_TOKEN)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,7 +36,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.RELEASE_TOKEN || github.token }}
+          # Use the workflow's GITHUB_TOKEN for git operations. It is always
+          # valid and has contents:write (declared above), which is all this
+          # job needs to push the tag and create the release. (A stale
+          # RELEASE_TOKEN PAT previously broke checkout with an auth failure.)
+          token: ${{ github.token }}
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v2
@@ -145,7 +149,7 @@ jobs:
           prerelease: false
           files: |
             dist/**/*
-          token: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Summary
         run: |

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -113,7 +113,7 @@ export default withMermaid(
             price: '0',
             priceCurrency: 'USD',
           },
-          softwareVersion: '0.2.1',
+          softwareVersion: '0.3.0',
           programmingLanguage: 'TypeScript',
           codeRepository: 'https://github.com/cameronrye/atproto-mcp',
           license: 'https://opensource.org/licenses/MIT',


### PR DESCRIPTION
## Why

Follow-up to #18. The dry-run of Manual Publish for v0.3.0 failed at the **Checkout** step:

```
fatal: could not read Username for 'https://github.com': terminal prompts disabled
```

The job authenticated git with `secrets.RELEASE_TOKEN || github.token`. `RELEASE_TOKEN` (a PAT from 2025-11-18) is now **invalid/expired**, so it was used and checkout failed before reaching any publish logic.

## Fix

- **Checkout + GitHub Release** now use `GITHUB_TOKEN`, which is always valid and already has `contents: write` (declared in the job) — enough to push the `v0.3.0` tag and create the release. npm auth is separate (`NPM_TOKEN`) and unaffected.
- Bump docs structured-data `softwareVersion` to `0.3.0` (the live site still said 0.2.1).

### Note on the trigger chain
RELEASE_TOKEN existed so the tag push would re-trigger `release.yml`. With `GITHUB_TOKEN` the tag won't trigger it — but that's fine: **publish.yml creates the GitHub Release itself**, and **docs deploy via `docs.yml` on push to main**. This also avoids the duplicate-release race that reddened the 0.2.1 runs. (Rotating RELEASE_TOKEN later would restore the auto-trigger if desired.)