### PR TITLE
ci: publish to npm via OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -50,9 +50,22 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          # npm trusted publishing (OIDC) requires Node >= 22.14.0 and npm >= 11.5.1.
+          # NOTE: intentionally NO `registry-url`. setup-node only writes an .npmrc
+          # auth line + exports a dummy NODE_AUTH_TOKEN (XXXXX-XXXXX-...) when
+          # registry-url is set; that placeholder masks OIDC failures as opaque
+          # E404s. (The fix that drops the dummy, actions/setup-node#1558, is not in
+          # any release yet.) Without registry-url there is no token to interfere,
+          # and `npm publish` defaults to registry.npmjs.org where OIDC + automatic
+          # provenance run on a clean slate.
+          node-version: 22
           cache: 'pnpm'
-          registry-url: 'https://registry.npmjs.org'
+
+      - name: Upgrade npm for trusted publishing
+        # The Node 22 runner ships npm 10.x; OIDC trusted publishing needs >= 11.5.1.
+        # We publish the final tarball with `npm publish` (pnpm has no native OIDC
+        # support — its publish just shells out to npm), so npm itself must be recent.
+        run: npm install -g npm@latest
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -86,17 +99,20 @@ jobs:
         if: inputs.dry_run
         run: |
           echo "🔍 DRY RUN: Would publish version ${{ inputs.version }} with tag ${{ inputs.tag }}"
-          pnpm publish --dry-run --tag ${{ inputs.tag }} --no-git-checks --provenance
+          npm publish --dry-run --tag ${{ inputs.tag }} --access public
           echo "✅ Dry run completed successfully"
 
       - name: Publish to npm
         if: '!inputs.dry_run'
+        # Authenticated via OIDC trusted publishing — no NODE_AUTH_TOKEN/NPM_TOKEN.
+        # Requires the `id-token: write` permission above AND a trusted publisher
+        # configured on npmjs.com for this repo + workflow file (publish.yml).
+        # Provenance is generated automatically under trusted publishing, so the
+        # --provenance flag is no longer needed.
         run: |
           echo "📦 Publishing version ${{ inputs.version }} with tag ${{ inputs.tag }}"
-          pnpm publish --tag ${{ inputs.tag }} --no-git-checks --provenance --access public
+          npm publish --tag ${{ inputs.tag }} --access public
           echo "✅ Published successfully"
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Create git tag
         if: '!inputs.dry_run && inputs.tag == ''latest'''


### PR DESCRIPTION
## Why

`Manual Publish` failed again on 0.3.0 with an opaque `E404` on `PUT https://registry.npmjs.org/atproto-mcp`. npm masks an expired/unauthorized token as a 404, and the `NPM_TOKEN` secret (last set 2025-11-18) had lapsed. 0.3.0 never published — the registry is still at 0.2.1. This is the **second** token-related publish break, so this moves auth off long-lived tokens entirely.

## What

Migrate the publish to **npm OIDC trusted publishing** (no `NPM_TOKEN`):

- **`npm publish` instead of `pnpm publish`** — pnpm has no native OIDC; it shells out to npm, so npm must drive the publish ([pnpm#9812](https://github.com/pnpm/pnpm/issues/9812)).
- **Upgrade npm to `@latest` (>= 11.5.1)** and **Node to 22** — both required for trusted publishing ([docs](https://docs.npmjs.com/trusted-publishers/)). Also clears the Node-20-action deprecation.
- **Drop `registry-url` from `setup-node`** — when set, `setup-node@v4` injects a dummy `NODE_AUTH_TOKEN` that masks OIDC failures as the *same* opaque E404. The fix that removes it ([actions/setup-node#1558](https://github.com/actions/setup-node/pull/1558)) isn't in any release yet, so we drop `registry-url`; `npm publish` defaults to `registry.npmjs.org` and OIDC runs on a clean slate.
- **Drop `--provenance`** — automatic under trusted publishing.

## Required before this can publish (one-time, on npmjs.com)

Add a Trusted Publisher to the `atproto-mcp` package → GitHub Actions:
- Organization or user: `cameronrye`
- Repository: `atproto-mcp`
- Workflow filename: `publish.yml` (filename only)
- Environment: leave blank
- Allowed action: `npm publish`

Then dispatch `publish.yml` with `dry_run=true` to validate, then `dry_run=false`.

## Verification

YAML validated. Requirements cross-checked against the official npm trusted-publishing docs and npm CLI / setup-node source (dummy-token behavior confirmed in setup-node `src/authutil.ts`).