### PR TITLE
ci: stop uploading dist/ as GitHub Release assets

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -163,8 +163,10 @@ jobs:
             For more information, see the [documentation](https://cameronrye.github.io/atproto-mcp).
           draft: false
           prerelease: false
-          files: |
-            dist/**/*
+          # No `files:` — the npm registry is the canonical artifact. Uploading the
+          # raw dist/ tree as release assets fails because GitHub flattens asset
+          # names and dist has colliding basenames (index.d.ts/index.js in several
+          # subdirs), which 404s the upload and reds the whole publish run.
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Summary


### PR DESCRIPTION
The `Create GitHub Release` step uploaded `files: dist/**/*`. GitHub release assets are a flat namespace and `dist/` has colliding basenames (`index.d.ts`/`index.js` in `types/`, `tools/`, `resources/`, …), so the upload 404s on the first collision (`Failed to upload release asset index.d.ts ... 404`) and reds the whole publish run.

This was latent until now — publishing always failed at the npm step before reaching the release step. With OIDC trusted publishing working (verified: exchange returns HTTP 201), the release step now runs, so this needs fixing for a clean end-to-end publish. The npm registry is the canonical artifact; drop the asset upload and keep the release notes.