### PR TITLE
End-to-end review: correctness, security, firehose, and CI fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Setup pnpm
         # Pinned to a commit SHA (supply-chain hardening); version is read from
@@ -27,7 +27,7 @@ jobs:
         uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
 
       - name: Setup Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'pnpm'
@@ -71,13 +71,13 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Setup pnpm
         uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 20
           cache: 'pnpm'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,9 +22,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: 10
+        # Pinned to a commit SHA (supply-chain hardening); version is read from
+        # the `packageManager` field in package.json, so no `version:` input.
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
 
       - name: Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
@@ -58,7 +58,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: matrix.node-version == 20
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@ab904c41d6ece82784817410c45d8b8c02684457 # v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage/lcov.info
@@ -74,9 +74,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: 10
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -33,9 +33,8 @@ jobs:
           fetch-depth: 0 # Needed for VitePress lastUpdated
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: 10
+        # Pinned to a commit SHA; version read from package.json packageManager.
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,10 +1,10 @@
 name: Integration Tests
 
 on:
-  push:
-    branches: [main, develop]
-  pull_request:
-    branches: [main, develop]
+  # These tests hit the live Bluesky network and self-document as occasionally
+  # flaky (rate limiting / transient network). They are intentionally NOT run on
+  # push/PR — a Bluesky hiccup must not red an unrelated change. Hermetic unit
+  # tests cover PRs (see ci.yml); live coverage runs on a schedule / on demand.
   schedule:
     # Run daily at 2 AM UTC
     - cron: '0 2 * * *'
@@ -35,7 +35,8 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2
+        # Pinned to a commit SHA; version read from package.json packageManager.
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -73,7 +74,8 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2
+        # Pinned to a commit SHA; version read from package.json packageManager.
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,9 +43,9 @@ jobs:
           token: ${{ github.token }}
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: 10
+        # Pinned to a commit SHA (this workflow holds id-token:write / OIDC publish
+        # authority — pin every action). Version comes from packageManager.
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -139,7 +139,7 @@ jobs:
 
       - name: Create GitHub Release
         if: '!inputs.dry_run && inputs.tag == ''latest'''
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v1
         with:
           tag_name: v${{ inputs.version }}
           name: Release v${{ inputs.version }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,7 +34,9 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        # Pinned to a commit SHA — this workflow holds id-token:write / OIDC
+        # publish authority, so every action is pinned (not a mutable tag).
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           # Use the workflow's GITHUB_TOKEN for git operations. It is always
           # valid and has contents:write (declared above), which is all this
@@ -48,7 +50,8 @@ jobs:
         uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        # Pinned to a commit SHA (OIDC publish authority — pin every action).
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           # npm trusted publishing (OIDC) requires Node >= 22.14.0 and npm >= 11.5.1.
           # NOTE: intentionally NO `registry-url`. setup-node only writes an .npmrc

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,9 +21,8 @@ jobs:
           fetch-depth: 0
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: 10
+        # Pinned to a commit SHA; version comes from package.json packageManager.
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -79,7 +78,7 @@ jobs:
           echo "EOF" >> $GITHUB_OUTPUT
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v1
         with:
           tag_name: ${{ steps.version.outputs.tag }}
           name: Release ${{ steps.version.outputs.tag }}
@@ -103,8 +102,10 @@ jobs:
             For more information, see the [documentation](https://cameronrye.github.io/atproto-mcp).
           draft: false
           prerelease: ${{ contains(steps.version.outputs.version, '-') }}
-          files: |
-            dist/**/*
+          # No `files:` — the npm registry is the canonical artifact. Uploading the
+          # raw dist/ tree fails because GitHub flattens asset names and dist has
+          # colliding basenames (index.js/index.d.ts in several subdirs), which
+          # 404s the upload and reds the release (matches publish.yml).
 
       # NOTE: npm publishing is owned by the "Manual Publish" workflow
       # (.github/workflows/publish.yml), which publishes with OIDC provenance and
@@ -130,9 +131,8 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: 10
+        # Pinned to a commit SHA; version comes from package.json packageManager.
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,62 +1,59 @@
 # Multi-stage Docker build for AT Protocol MCP Server
+#
+# This project uses pnpm (see packageManager in package.json) and ships only a
+# pnpm-lock.yaml — there is no package-lock.json, so `npm ci` cannot be used.
 FROM node:20-alpine AS builder
 
-# Set working directory
 WORKDIR /app
 
-# Copy package files
-COPY package*.json ./
+# Enable the pnpm version pinned by package.json's "packageManager" field.
+RUN corepack enable
 
-# Install dependencies
-RUN npm ci --only=production
+# Copy manifest + lockfile first for better layer caching.
+COPY package.json pnpm-lock.yaml ./
 
-# Copy source code
+# Install ALL dependencies (including devDeps) — the build needs tsc/tsx.
+RUN pnpm install --frozen-lockfile
+
+# Copy source and build.
 COPY . .
-
-# Build the application
-RUN npm run build
+RUN pnpm run build
 
 # Production stage
 FROM node:20-alpine AS production
 
-# Install dumb-init for proper signal handling
+# Install dumb-init for proper signal handling.
 RUN apk add --no-cache dumb-init
 
-# Create non-root user
+# Enable pnpm for the production install.
+RUN corepack enable
+
+# Create non-root user.
 RUN addgroup -g 1001 -S nodejs && \
     adduser -S atproto -u 1001
 
-# Set working directory
 WORKDIR /app
 
-# Copy package files
-COPY package*.json ./
+# Copy manifest + lockfile and install only production dependencies.
+COPY package.json pnpm-lock.yaml ./
+RUN pnpm install --frozen-lockfile --prod && \
+    pnpm store prune
 
-# Install only production dependencies
-RUN npm ci --only=production && npm cache clean --force
-
-# Copy built application from builder stage
+# Copy built application from the builder stage.
 COPY --from=builder /app/dist ./dist
 
-# Copy configuration files
-COPY --from=builder /app/config ./config
-
-# Create necessary directories
+# Create runtime directories and hand ownership to the non-root user.
 RUN mkdir -p /app/logs /app/data && \
     chown -R atproto:nodejs /app
 
-# Switch to non-root user
 USER atproto
 
-# Expose port
-EXPOSE 3000
-
-# Health check
+# Note: this server speaks MCP over stdio and binds no network port, so there is
+# no EXPOSE. The health check is a process-local smoke check (see health-check.ts).
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
   CMD node dist/health-check.js || exit 1
 
-# Use dumb-init to handle signals properly
+# Use dumb-init to handle signals (SIGTERM/SIGINT) properly.
 ENTRYPOINT ["dumb-init", "--"]
 
-# Start the application
 CMD ["node", "dist/cli.js"]

--- a/src/__tests__/find-influential-batching.test.ts
+++ b/src/__tests__/find-influential-batching.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Regression/perf test: find_influential_users must hydrate author profiles via
+ * the batched getProfiles endpoint (up to 25 actors per call) instead of issuing
+ * one sequential getProfile round-trip per author.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { FindInfluentialUsersTool } from '../tools/implementations/analytics-tools.js';
+import type { AtpClient } from '../utils/atp-client.js';
+
+function mockClient() {
+  const searchPosts = vi.fn().mockResolvedValue({
+    data: {
+      posts: [
+        { author: { did: 'did:a' } },
+        { author: { did: 'did:b' } },
+        { author: { did: 'did:a' } },
+      ],
+    },
+  });
+  const getProfiles = vi.fn().mockResolvedValue({
+    data: {
+      profiles: [
+        { did: 'did:a', handle: 'a.test', followersCount: 500, followsCount: 10, postsCount: 20 },
+        { did: 'did:b', handle: 'b.test', followersCount: 300, followsCount: 5, postsCount: 8 },
+      ],
+    },
+  });
+  const getProfile = vi.fn();
+  const agent = {
+    app: { bsky: { feed: { searchPosts } } },
+    getProfiles,
+    getProfile,
+    session: { did: 'did:self' },
+  };
+
+  const wrap = async (op: () => unknown) => {
+    try {
+      return { success: true, data: await op() };
+    } catch (error) {
+      return { success: false, error };
+    }
+  };
+  const client = {
+    getAgent: vi.fn().mockReturnValue(agent),
+    isAuthenticated: vi.fn().mockReturnValue(false),
+    hasCredentials: vi.fn().mockReturnValue(false),
+    executePublicRequest: vi.fn().mockImplementation(wrap),
+    executeAuthenticatedRequest: vi.fn().mockImplementation(wrap),
+  } as unknown as AtpClient;
+
+  return { client, getProfiles, getProfile };
+}
+
+describe('find_influential_users profile batching', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('hydrates profiles via getProfiles, not per-author getProfile', async () => {
+    const { client, getProfiles, getProfile } = mockClient();
+    const tool = new FindInfluentialUsersTool(client);
+
+    const result = await tool.handler({ topic: 'cats', minFollowers: 0, maxResults: 10 });
+
+    expect(getProfiles).toHaveBeenCalled();
+    expect(getProfile).not.toHaveBeenCalled();
+    expect(result.users.length).toBe(2);
+  });
+});

--- a/src/__tests__/follow-user.test.ts
+++ b/src/__tests__/follow-user.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Unit tests for FollowUserTool duplicate-follow detection.
+ *
+ * Regression guard for the bug where existing-follow detection scanned only the
+ * first 100 follow records via listRecords, missing matches on accounts that
+ * follow >100 users and creating duplicate follow records. Detection must use
+ * the authoritative `viewer.following` signal from getProfile instead.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { FollowUserTool } from '../tools/implementations/follow-user-tool.js';
+import type { AtpClient } from '../utils/atp-client.js';
+
+interface IMockOptions {
+  following?: string; // viewer.following AT-URI, if already following
+}
+
+const createMockAtpClient = (opts: IMockOptions = {}) => {
+  const createRecord = vi.fn().mockResolvedValue({
+    data: {
+      uri: 'at://did:plc:self/app.bsky.graph.follow/new',
+      cid: 'cidnew',
+    },
+  });
+
+  // listRecords intentionally returns an EMPTY page to simulate the target
+  // follow living beyond the first 100 records (the original bug condition).
+  const listRecords = vi.fn().mockResolvedValue({ data: { records: [] } });
+
+  const getProfile = vi.fn().mockResolvedValue({
+    data: {
+      did: 'did:plc:target',
+      handle: 'target.bsky.social',
+      ...(opts.following ? { viewer: { following: opts.following } } : { viewer: {} }),
+    },
+  });
+
+  const mockAgent = {
+    getProfile,
+    com: { atproto: { repo: { createRecord, listRecords } } },
+    session: { did: 'did:plc:self' },
+  };
+
+  const client = {
+    getAgent: vi.fn().mockReturnValue(mockAgent),
+    isAuthenticated: vi.fn().mockReturnValue(true),
+    hasCredentials: vi.fn().mockReturnValue(true),
+    executeAuthenticatedRequest: vi.fn().mockImplementation(async (operation: () => unknown) => {
+      try {
+        return { success: true, data: await operation() };
+      } catch (error) {
+        return { success: false, error };
+      }
+    }),
+  } as unknown as AtpClient;
+
+  return { client, createRecord, listRecords, getProfile };
+};
+
+describe('FollowUserTool duplicate detection', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('does not create a duplicate when viewer.following is set but listRecords is empty', async () => {
+    const existingUri = 'at://did:plc:self/app.bsky.graph.follow/existing';
+    const { client, createRecord } = createMockAtpClient({ following: existingUri });
+    const tool = new FollowUserTool(client);
+
+    const result = await tool.handler({ actor: 'target.bsky.social' });
+
+    expect(createRecord).not.toHaveBeenCalled();
+    expect(result.uri).toBe(existingUri);
+    expect(result.message).toMatch(/already/i);
+  });
+
+  it('creates a follow when viewer.following is not set', async () => {
+    const { client, createRecord } = createMockAtpClient({});
+    const tool = new FollowUserTool(client);
+
+    const result = await tool.handler({ actor: 'target.bsky.social' });
+
+    expect(createRecord).toHaveBeenCalledTimes(1);
+    expect(result.uri).toBe('at://did:plc:self/app.bsky.graph.follow/new');
+    expect(result.message).toMatch(/followed successfully/i);
+  });
+});

--- a/src/__tests__/get-user-profile.test.ts
+++ b/src/__tests__/get-user-profile.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Unit tests for GetUserProfileTool.getProfiles batching.
+ *
+ * app.bsky.actor.getProfiles caps `actors` at 25 per call, so requests with
+ * more than 25 actors must be chunked or the whole call fails at the API.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { GetUserProfileTool } from '../tools/implementations/get-user-profile-tool.js';
+import type { AtpClient } from '../utils/atp-client.js';
+
+const createMockAtpClient = () => {
+  const getProfiles = vi.fn().mockImplementation(async ({ actors }: { actors: string[] }) => ({
+    data: {
+      profiles: actors.map(actor => ({
+        did: `did:plc:${actor}`,
+        handle: `${actor}.bsky.social`,
+      })),
+    },
+  }));
+
+  const mockAgent = { getProfiles };
+
+  const client = {
+    getAgent: vi.fn().mockReturnValue(mockAgent),
+    isAuthenticated: vi.fn().mockReturnValue(true),
+    hasCredentials: vi.fn().mockReturnValue(true),
+    executeAuthenticatedRequest: vi.fn().mockImplementation(async (operation: () => unknown) => {
+      try {
+        return { success: true, data: await operation() };
+      } catch (error) {
+        return { success: false, error };
+      }
+    }),
+    executePublicRequest: vi.fn().mockImplementation(async (operation: () => unknown) => {
+      try {
+        return { success: true, data: await operation() };
+      } catch (error) {
+        return { success: false, error };
+      }
+    }),
+  } as unknown as AtpClient;
+
+  return { client, getProfiles };
+};
+
+describe('GetUserProfileTool.getProfiles batching', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('chunks requests of more than 25 actors into multiple API calls', async () => {
+    const { client, getProfiles } = createMockAtpClient();
+    const tool = new GetUserProfileTool(client);
+
+    const actors = Array.from({ length: 30 }, (_, i) => `user${i}.bsky.social`);
+    const result = await tool.getProfiles(actors);
+
+    // 30 actors -> two calls (25 + 5), never a single >25 call.
+    expect(getProfiles).toHaveBeenCalledTimes(2);
+    for (const call of getProfiles.mock.calls) {
+      expect(call[0].actors.length).toBeLessThanOrEqual(25);
+    }
+    expect(result.profiles).toHaveLength(30);
+  });
+
+  it('makes a single call for 25 or fewer actors', async () => {
+    const { client, getProfiles } = createMockAtpClient();
+    const tool = new GetUserProfileTool(client);
+
+    const actors = Array.from({ length: 25 }, (_, i) => `user${i}.bsky.social`);
+    const result = await tool.getProfiles(actors);
+
+    expect(getProfiles).toHaveBeenCalledTimes(1);
+    expect(result.profiles).toHaveLength(25);
+  });
+});

--- a/src/__tests__/media-mime.test.ts
+++ b/src/__tests__/media-mime.test.ts
@@ -1,0 +1,28 @@
+/**
+ * Regression test: link-preview thumbnails must only be uploaded with a validated
+ * image MIME type. Previously the remote server's Content-Type header was passed
+ * straight to uploadBlob, so a non-image response could be stored as a blob.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { safeImageMime } from '../tools/implementations/media-tools.js';
+
+describe('safeImageMime', () => {
+  it('accepts known image content types (normalized)', () => {
+    expect(safeImageMime('image/jpeg')).toBe('image/jpeg');
+    expect(safeImageMime('image/png')).toBe('image/png');
+    expect(safeImageMime('image/gif')).toBe('image/gif');
+    expect(safeImageMime('image/webp')).toBe('image/webp');
+    // case-insensitive + strips parameters
+    expect(safeImageMime('IMAGE/WEBP')).toBe('image/webp');
+    expect(safeImageMime('image/jpeg; charset=binary')).toBe('image/jpeg');
+  });
+
+  it('rejects non-image / missing content types', () => {
+    expect(safeImageMime('text/html')).toBeNull();
+    expect(safeImageMime('application/octet-stream')).toBeNull();
+    expect(safeImageMime('')).toBeNull();
+    expect(safeImageMime(null)).toBeNull();
+    expect(safeImageMime(undefined)).toBeNull();
+  });
+});

--- a/src/__tests__/quote-post-facets.test.ts
+++ b/src/__tests__/quote-post-facets.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Regression test: quote posts must run richtext facet detection so links,
+ * @mentions and #hashtags in the quote text are real facets (clickable / resolved)
+ * rather than inert plain text. Regular posts already do this via buildRichText;
+ * the quote-post path previously skipped it.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { RepostTool } from '../tools/implementations/repost-tool.js';
+import type { AtpClient } from '../utils/atp-client.js';
+
+function mockClient() {
+  const post = vi.fn().mockResolvedValue({ uri: 'at://quote', cid: 'cidquote' });
+  const agent = { post, session: { did: 'did:plc:self' } };
+
+  const client = {
+    getAgent: vi.fn().mockReturnValue(agent),
+    isAuthenticated: vi.fn().mockReturnValue(true),
+    hasCredentials: vi.fn().mockReturnValue(true),
+    executeAuthenticatedRequest: vi.fn().mockImplementation(async (op: () => unknown) => {
+      try {
+        return { success: true, data: await op() };
+      } catch (error) {
+        return { success: false, error };
+      }
+    }),
+  } as unknown as AtpClient;
+
+  return { client, post };
+}
+
+describe('quote post facet detection', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('attaches detected facets (e.g. a link) to the quote post record', async () => {
+    const { client, post } = mockClient();
+    const tool = new RepostTool(client);
+
+    await tool.handler({
+      uri: 'at://did:plc:author/app.bsky.feed.post/1',
+      cid: 'bafyreiabc123',
+      text: 'check https://example.com now',
+    });
+
+    expect(post).toHaveBeenCalledTimes(1);
+    const record = post.mock.calls[0][0] as { text: string; facets?: unknown[]; embed?: any };
+    expect(Array.isArray(record.facets)).toBe(true);
+    expect(record.facets!.length).toBeGreaterThan(0);
+    // The embedded quote is still present.
+    expect(record.embed?.$type).toBe('app.bsky.embed.record');
+  });
+});

--- a/src/__tests__/read-only-tool-availability.test.ts
+++ b/src/__tests__/read-only-tool-availability.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Regression tests: read-only tools that work against the public AppView must be
+ * available in unauthenticated mode (ENHANCED), not gated behind auth (PRIVATE).
+ * Also covers get_list reporting the list's true size, not just the current page.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  GetListTool,
+  GetThreadTool,
+  GetCustomFeedTool,
+} from '../tools/implementations/advanced-social-tools.js';
+import { AnalyzeModerationStatusTool } from '../tools/implementations/moderation-tools.js';
+import type { AtpClient } from '../utils/atp-client.js';
+
+const unauthClient = {
+  isAuthenticated: vi.fn().mockReturnValue(false),
+  hasCredentials: vi.fn().mockReturnValue(false),
+} as unknown as AtpClient;
+
+describe('read-only tools are available unauthenticated', () => {
+  it('get_list is available without authentication', () => {
+    expect(new GetListTool(unauthClient).isAvailable()).toBe(true);
+  });
+
+  it('get_thread is available without authentication', () => {
+    expect(new GetThreadTool(unauthClient).isAvailable()).toBe(true);
+  });
+
+  it('get_custom_feed is available without authentication', () => {
+    expect(new GetCustomFeedTool(unauthClient).isAvailable()).toBe(true);
+  });
+
+  it('analyze_moderation_status is available without authentication', () => {
+    expect(new AnalyzeModerationStatusTool(unauthClient).isAvailable()).toBe(true);
+  });
+});
+
+describe('get_list itemCount reflects the whole list, not the current page', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('reports list.listItemCount rather than items.length', async () => {
+    const getList = vi.fn().mockResolvedValue({
+      data: {
+        list: {
+          uri: 'at://did:plc:owner/app.bsky.graph.list/abc',
+          name: 'My List',
+          description: 'desc',
+          purpose: 'app.bsky.graph.defs#curatelist',
+          creator: { did: 'did:plc:owner', handle: 'owner.test' },
+          listItemCount: 250,
+        },
+        items: [
+          {
+            uri: 'at://item/1',
+            subject: { did: 'did:plc:a', handle: 'a.test' },
+          },
+        ],
+        cursor: undefined,
+      },
+    });
+    const agent = { getAgent: vi.fn(), app: { bsky: { graph: { getList } } } };
+
+    const client = {
+      getAgent: vi.fn().mockReturnValue(agent),
+      isAuthenticated: vi.fn().mockReturnValue(false),
+      hasCredentials: vi.fn().mockReturnValue(false),
+      executePublicRequest: vi.fn().mockImplementation(async (op: () => unknown) => ({
+        success: true,
+        data: await op(),
+      })),
+      executeAuthenticatedRequest: vi.fn().mockImplementation(async (op: () => unknown) => ({
+        success: true,
+        data: await op(),
+      })),
+    } as unknown as AtpClient;
+
+    const tool = new GetListTool(client);
+    const result = await tool.handler({ listUri: 'at://did:plc:owner/app.bsky.graph.list/abc' });
+
+    expect(result.list.itemCount).toBe(250);
+  });
+});

--- a/src/__tests__/recommend-content.test.ts
+++ b/src/__tests__/recommend-content.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Regression test: recommend_content's `excludeReposts` flag must actually
+ * exclude reposts. The repost indicator lives on the feed item's `reason`
+ * (app.bsky.feed.defs#reasonRepost), not on the post record, so the previous
+ * `record.repost` check was a silent no-op.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { RecommendContentTool } from '../tools/implementations/content-discovery-tools.js';
+import type { AtpClient } from '../utils/atp-client.js';
+
+function feedItem(uri: string, opts: { repost?: boolean } = {}) {
+  const post = {
+    uri,
+    cid: `cid-${uri}`,
+    author: { did: 'did:plc:author', handle: 'author.test', displayName: 'Author' },
+    record: { text: 'hello world', createdAt: new Date().toISOString() },
+    likeCount: 10,
+    replyCount: 0,
+    repostCount: 0,
+    indexedAt: new Date().toISOString(),
+    viewer: {},
+  };
+  return opts.repost ? { post, reason: { $type: 'app.bsky.feed.defs#reasonRepost' } } : { post };
+}
+
+function mockClient() {
+  const getTimeline = vi.fn().mockResolvedValue({
+    data: { feed: [feedItem('at://normal'), feedItem('at://repost', { repost: true })] },
+  });
+  const getProfile = vi.fn().mockResolvedValue({ data: { did: 'did:plc:self', handle: 'self' } });
+  const agent = { session: { did: 'did:plc:self' }, getTimeline, getProfile };
+
+  const client = {
+    getAgent: vi.fn().mockReturnValue(agent),
+    isAuthenticated: vi.fn().mockReturnValue(true),
+    hasCredentials: vi.fn().mockReturnValue(true),
+    executeAuthenticatedRequest: vi.fn().mockImplementation(async (op: () => unknown) => {
+      try {
+        return { success: true, data: await op() };
+      } catch (error) {
+        return { success: false, error };
+      }
+    }),
+  } as unknown as AtpClient;
+
+  return { client };
+}
+
+describe('recommend_content excludeReposts', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('excludes reposted feed items when excludeReposts is true', async () => {
+    const { client } = mockClient();
+    const tool = new RecommendContentTool(client);
+
+    const result = await tool.handler({ excludeReposts: true });
+    const uris = result.recommendations.map((r: { uri: string }) => r.uri);
+
+    expect(uris).toContain('at://normal');
+    expect(uris).not.toContain('at://repost');
+  });
+
+  it('includes reposted feed items when excludeReposts is false', async () => {
+    const { client } = mockClient();
+    const tool = new RecommendContentTool(client);
+
+    const result = await tool.handler({ excludeReposts: false });
+    const uris = result.recommendations.map((r: { uri: string }) => r.uri);
+
+    expect(uris).toContain('at://normal');
+    expect(uris).toContain('at://repost');
+  });
+});

--- a/src/__tests__/tool-dispatch.test.ts
+++ b/src/__tests__/tool-dispatch.test.ts
@@ -52,28 +52,26 @@ describe('MCP tool dispatch (real Server + in-memory transport)', () => {
     // dispatch bug, only the LAST tool (extract_media_from_post) is reachable and
     // this call is rejected by a literal-name schema mismatch instead of routing
     // to get_user_profile. A correct router reaches the tool, whose own validation
-    // then complains about the missing required `actor` argument.
-    await expect(client.callTool({ name: 'get_user_profile', arguments: {} })).rejects.toThrow(
-      /actor/i
-    );
+    // then complains about the missing required `actor` argument. Per the MCP
+    // contract, that execution/validation error comes back as an isError result,
+    // not a JSON-RPC rejection.
+    const res = await client.callTool({ name: 'get_user_profile', arguments: {} });
+    expect(res.isError).toBe(true);
+    expect(JSON.stringify(res.content)).toMatch(/actor/i);
   });
 
   it('routes tools/call to multiple distinct tools (never the literal-mismatch parse error)', async () => {
     await connect();
     // Each of these errors deterministically without a network call: get_user_profile
     // fails validation (missing actor); the write tools are unavailable in
-    // unauthenticated mode. The point is that every one is REACHED — pre-fix, every
-    // non-last tool was instead rejected with a Zod literal mismatch against the only
-    // surviving handler (`expected "extract_media_from_post"`).
+    // unauthenticated mode. Both surface as isError tool results. The point is that
+    // every one is REACHED — pre-fix, every non-last tool was instead rejected with a
+    // Zod literal mismatch against the only surviving handler ("extract_media_from_post").
     for (const name of ['get_user_profile', 'create_post', 'like_post', 'block_user']) {
-      let message = '';
-      try {
-        await client.callTool({ name, arguments: {} });
-      } catch (error) {
-        message = error instanceof Error ? error.message : String(error);
-      }
-      expect(message, `${name} should have produced an error`).not.toBe('');
-      expect(message, `${name} was rejected by the wrong (last-tool) handler`).not.toMatch(
+      const res = await client.callTool({ name, arguments: {} });
+      const text = JSON.stringify(res.content);
+      expect(res.isError, `${name} should have produced a tool-error result`).toBe(true);
+      expect(text, `${name} was rejected by the wrong (last-tool) handler`).not.toMatch(
         /invalid_literal|expected.*extract_media_from_post/i
       );
     }

--- a/src/__tests__/update-profile-cas.test.ts
+++ b/src/__tests__/update-profile-cas.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Regression test: update_profile is a read-modify-write on the single
+ * app.bsky.actor.profile/self record, so it must use compare-and-swap
+ * (swapRecord = the CID it read) to avoid clobbering a concurrent update.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { UpdateProfileTool } from '../tools/implementations/content-management-tools.js';
+import type { AtpClient } from '../utils/atp-client.js';
+
+function mockClient() {
+  const getRecord = vi
+    .fn()
+    .mockResolvedValue({ data: { value: { displayName: 'Old' }, cid: 'cidA' } });
+  const putRecord = vi.fn().mockResolvedValue({ data: { uri: 'at://x', cid: 'cidB' } });
+  const agent = {
+    session: { did: 'did:plc:self' },
+    com: { atproto: { repo: { getRecord, putRecord } } },
+  };
+
+  const client = {
+    getAgent: vi.fn().mockReturnValue(agent),
+    isAuthenticated: vi.fn().mockReturnValue(true),
+    hasCredentials: vi.fn().mockReturnValue(true),
+    executeAuthenticatedRequest: vi.fn().mockImplementation(async (op: () => unknown) => {
+      try {
+        return { success: true, data: await op() };
+      } catch (error) {
+        return { success: false, error };
+      }
+    }),
+  } as unknown as AtpClient;
+
+  return { client, getRecord, putRecord };
+}
+
+describe('update_profile compare-and-swap', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('passes swapRecord equal to the CID it read', async () => {
+    const { client, putRecord } = mockClient();
+    const tool = new UpdateProfileTool(client);
+
+    await tool.handler({ displayName: 'New' });
+
+    expect(putRecord).toHaveBeenCalledTimes(1);
+    expect(putRecord).toHaveBeenCalledWith(expect.objectContaining({ swapRecord: 'cidA' }));
+  });
+});

--- a/src/__tests__/uri-safety-destructive.test.ts
+++ b/src/__tests__/uri-safety-destructive.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Regression tests: destructive tools must never delete an arbitrary record type
+ * chosen by an (untrusted) caller-supplied URI.
+ *
+ * unlike_post / unrepost / delete_post previously took the `collection` (and
+ * `repo`) straight from the supplied URI and passed them to deleteRecord without
+ * pinning the expected NSID. A crafted URI such as
+ * at://<self-did>/app.bsky.graph.follow/<rkey> handed to unlike_post would delete
+ * one of the user's follows. The fix pins the collection (via the SDK
+ * deleteLike/deleteRepost helpers, or an explicit assertion for delete_post).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { UnlikePostTool } from '../tools/implementations/like-post-tool.js';
+import { UnrepostTool } from '../tools/implementations/repost-tool.js';
+import { DeletePostTool } from '../tools/implementations/content-management-tools.js';
+import { ValidationError } from '../types/index.js';
+import type { AtpClient } from '../utils/atp-client.js';
+
+const SELF = 'did:plc:self';
+
+function mockClient() {
+  const deleteLike = vi.fn().mockResolvedValue(undefined);
+  const deleteRepost = vi.fn().mockResolvedValue(undefined);
+  const deleteRecord = vi.fn().mockResolvedValue({ data: {} });
+  const getRecord = vi.fn().mockResolvedValue({ data: { uri: '', cid: 'cid', value: {} } });
+
+  const agent = {
+    deleteLike,
+    deleteRepost,
+    com: { atproto: { repo: { deleteRecord, getRecord } } },
+    session: { did: SELF },
+  };
+
+  const client = {
+    getAgent: vi.fn().mockReturnValue(agent),
+    isAuthenticated: vi.fn().mockReturnValue(true),
+    hasCredentials: vi.fn().mockReturnValue(true),
+    executeAuthenticatedRequest: vi.fn().mockImplementation(async (op: () => unknown) => {
+      try {
+        return { success: true, data: await op() };
+      } catch (error) {
+        return { success: false, error };
+      }
+    }),
+  } as unknown as AtpClient;
+
+  return { client, deleteLike, deleteRepost, deleteRecord, getRecord };
+}
+
+describe('destructive-tool URI safety', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  describe('unlike_post', () => {
+    it('refuses a URI whose collection is not app.bsky.feed.like', async () => {
+      const { client, deleteLike, deleteRecord } = mockClient();
+      const tool = new UnlikePostTool(client);
+
+      await expect(
+        tool.handler({ likeUri: `at://${SELF}/app.bsky.feed.post/abc` })
+      ).rejects.toBeInstanceOf(ValidationError);
+
+      expect(deleteLike).not.toHaveBeenCalled();
+      expect(deleteRecord).not.toHaveBeenCalled();
+    });
+
+    it('deletes a genuine like via the collection-pinned helper', async () => {
+      const { client, deleteLike } = mockClient();
+      const tool = new UnlikePostTool(client);
+      const likeUri = `at://${SELF}/app.bsky.feed.like/abc`;
+
+      const result = await tool.handler({ likeUri });
+
+      expect(deleteLike).toHaveBeenCalledWith(likeUri);
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe('unrepost', () => {
+    it('refuses a URI whose collection is not app.bsky.feed.repost', async () => {
+      const { client, deleteRepost, deleteRecord } = mockClient();
+      const tool = new UnrepostTool(client);
+
+      await expect(
+        tool.handler({ repostUri: `at://${SELF}/app.bsky.graph.follow/abc` })
+      ).rejects.toBeInstanceOf(ValidationError);
+
+      expect(deleteRepost).not.toHaveBeenCalled();
+      expect(deleteRecord).not.toHaveBeenCalled();
+    });
+
+    it('deletes a genuine repost via the collection-pinned helper', async () => {
+      const { client, deleteRepost } = mockClient();
+      const tool = new UnrepostTool(client);
+      const repostUri = `at://${SELF}/app.bsky.feed.repost/abc`;
+
+      const result = await tool.handler({ repostUri });
+
+      expect(deleteRepost).toHaveBeenCalledWith(repostUri);
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe('delete_post', () => {
+    it('refuses a non-post URI even when it belongs to the user', async () => {
+      const { client, deleteRecord } = mockClient();
+      const tool = new DeletePostTool(client);
+
+      await expect(
+        tool.handler({ uri: `at://${SELF}/app.bsky.graph.follow/abc` })
+      ).rejects.toBeInstanceOf(ValidationError);
+
+      expect(deleteRecord).not.toHaveBeenCalled();
+    });
+
+    it('deletes a genuine post, pinning repo to the session DID and the post collection', async () => {
+      const { client, deleteRecord } = mockClient();
+      const tool = new DeletePostTool(client);
+
+      const result = await tool.handler({ uri: `at://${SELF}/app.bsky.feed.post/abc` });
+
+      expect(deleteRecord).toHaveBeenCalledWith(
+        expect.objectContaining({ repo: SELF, collection: 'app.bsky.feed.post', rkey: 'abc' })
+      );
+      expect(result.success).toBe(true);
+    });
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,7 +70,11 @@ export class AtpMcpServer {
 
       // Initialize security manager
       const securityConfig: ISecurityConfig = {
-        enableInputSanitization: true,
+        // The blanket HTML/script InputSanitizer is intentionally NOT applied to
+        // tool arguments (it would corrupt legitimate post content). Per-field
+        // zod validation and url-safety guards are the real defenses, so this flag
+        // honestly reports that the object sanitizer does not run on the hot path.
+        enableInputSanitization: false,
         enableRateLimit: true,
         enableErrorSanitization: true,
         maxInputLength: 10000,
@@ -173,6 +177,20 @@ export class AtpMcpServer {
           });
         }
 
+        // Build an MCP "tool error" result. Per the MCP spec, errors that occur
+        // while a (known) tool runs — including invalid arguments, unavailable
+        // tools, and rate limiting — are reported as a result with isError: true,
+        // NOT as JSON-RPC protocol errors. This lets the calling model SEE the
+        // error text and react (fix arguments, authenticate, back off) instead of
+        // receiving an opaque transport failure. Protocol errors are reserved for
+        // problems with the request itself (e.g. an unknown tool, handled above).
+        const toolError = (
+          message: string
+        ): { content: Array<{ type: 'text'; text: string }>; isError: true } => ({
+          content: [{ type: 'text', text: message }],
+          isError: true,
+        });
+
         // Rate-limit tool invocations to guard against runaway loops / abuse.
         // Note: tool arguments are intentionally NOT passed through the HTML/script
         // input sanitizer — that sanitizer strips characters (`<`, `>`, collapses
@@ -180,34 +198,26 @@ export class AtpMcpServer {
         // data. Per-field validation is handled by each tool's zod schema, and
         // outbound URLs/paths are guarded at their call sites (see url-safety).
         if (!this.securityManager.checkRateLimit(`tool:${toolName}`)) {
-          throw new McpError(
-            ErrorCode.InternalError,
-            `Rate limit exceeded for tool "${toolName}". Please slow down and retry shortly.`,
-            { tool: toolName }
+          return toolError(
+            `Rate limit exceeded for tool "${toolName}". Please slow down and retry shortly.`
           );
         }
 
+        // Surface tool availability (e.g. requires authentication) as a result the
+        // model can act on, not a protocol error.
+        if (
+          'isAvailable' in tool &&
+          typeof tool.isAvailable === 'function' &&
+          !tool.isAvailable()
+        ) {
+          const availabilityMessage =
+            'getAvailabilityMessage' in tool && typeof tool.getAvailabilityMessage === 'function'
+              ? tool.getAvailabilityMessage()
+              : 'Tool not available';
+          return toolError(`Tool not available: ${availabilityMessage}`);
+        }
+
         try {
-          // Check if tool is available before execution
-          if ('isAvailable' in tool && typeof tool.isAvailable === 'function') {
-            if (!tool.isAvailable()) {
-              const availabilityMessage =
-                'getAvailabilityMessage' in tool &&
-                typeof tool.getAvailabilityMessage === 'function'
-                  ? tool.getAvailabilityMessage()
-                  : 'Tool not available';
-
-              throw new McpError(
-                ErrorCode.InternalError,
-                `Tool not available: ${availabilityMessage}`,
-                {
-                  tool: toolName,
-                  availability: availabilityMessage,
-                }
-              );
-            }
-          }
-
           const result = await tool.handler(request.params.arguments || {});
 
           // DESIGN DECISION: Return results as formatted JSON text for LLM consumption
@@ -249,16 +259,9 @@ export class AtpMcpServer {
         } catch (error) {
           this.logger.error(`Tool ${toolName} execution failed`, error);
 
-          // Re-throw protocol errors (unknown/unavailable tool) as-is so the
-          // client receives the accurate JSON-RPC code.
-          if (error instanceof McpError) {
-            throw error;
-          }
-
-          // Invalid input is a client-correctable condition: map it to the
-          // spec's InvalidParams (-32602) rather than InternalError (-32603).
+          // Invalid arguments are safe to surface verbatim so the model can fix them.
           if (error instanceof ValidationError) {
-            throw new McpError(ErrorCode.InvalidParams, error.message, { tool: toolName });
+            return toolError(`Invalid parameters: ${error.message}`);
           }
 
           // Sanitize internal error details before returning to the client.
@@ -266,18 +269,32 @@ export class AtpMcpServer {
             .getErrorSanitizer()
             .sanitizeError(error instanceof Error ? error : new Error(String(error)));
 
-          throw new McpError(
-            ErrorCode.InternalError,
-            `Tool execution failed: ${sanitized.message}`,
-            {
-              tool: toolName,
-            }
-          );
+          return toolError(`Tool execution failed: ${sanitized.message}`);
         }
       }
     );
 
     this.logger.info(`Registered ${tools.length} MCP tools`);
+  }
+
+  /**
+   * Normalize an error thrown inside a resource/prompt handler into an McpError:
+   * pass an existing McpError through, otherwise log + sanitize and wrap it as an
+   * InternalError. Returned (not thrown) so the caller writes `throw this.…`.
+   */
+  private toHandlerMcpError(
+    error: unknown,
+    label: string,
+    context: Record<string, unknown>
+  ): McpError {
+    this.logger.error(label, error);
+    if (error instanceof McpError) {
+      return error;
+    }
+    const sanitized = this.securityManager
+      .getErrorSanitizer()
+      .sanitizeError(error instanceof Error ? error : new Error(String(error)));
+    return new McpError(ErrorCode.InternalError, `${label}: ${sanitized.message}`, context);
   }
 
   /**
@@ -337,20 +354,9 @@ export class AtpMcpServer {
             ],
           };
         } catch (error) {
-          this.logger.error(`Resource read failed`, error);
-          if (error instanceof McpError) {
-            throw error;
-          }
-          const sanitized = this.securityManager
-            .getErrorSanitizer()
-            .sanitizeError(error instanceof Error ? error : new Error(String(error)));
-          throw new McpError(
-            ErrorCode.InternalError,
-            `Resource read failed: ${sanitized.message}`,
-            {
-              uri: request.params.uri,
-            }
-          );
+          throw this.toHandlerMcpError(error, 'Resource read failed', {
+            uri: request.params.uri,
+          });
         }
       }
     );
@@ -407,18 +413,9 @@ export class AtpMcpServer {
           const messages = await prompt.get(request.params.arguments ?? {});
           return { messages };
         } catch (error) {
-          this.logger.error(`Prompt generation failed`, error);
-          if (error instanceof McpError) {
-            throw error;
-          }
-          const sanitized = this.securityManager
-            .getErrorSanitizer()
-            .sanitizeError(error instanceof Error ? error : new Error(String(error)));
-          throw new McpError(
-            ErrorCode.InternalError,
-            `Prompt generation failed: ${sanitized.message}`,
-            { name: request.params.name }
-          );
+          throw this.toHandlerMcpError(error, 'Prompt generation failed', {
+            name: request.params.name,
+          });
         }
       }
     );

--- a/src/tools/implementations/__tests__/base-tool.test.ts
+++ b/src/tools/implementations/__tests__/base-tool.test.ts
@@ -103,7 +103,7 @@ describe('BaseTool', () => {
     it('should handle execution errors', async () => {
       const client = createMockAtpClient();
       const tool = new TestTool(client);
-      
+
       // Override execute to throw error
       tool['execute'] = vi.fn().mockRejectedValue(new Error('Test error'));
 
@@ -126,7 +126,9 @@ describe('BaseTool', () => {
     });
 
     it('should validate CID format', () => {
-      expect(() => tool['validateCid']('bafyreigbtj4x7ip5legnfznufuopl4sg4knzc2cof6duas4b3q2fy6swua')).not.toThrow();
+      expect(() =>
+        tool['validateCid']('bafyreigbtj4x7ip5legnfznufuopl4sg4knzc2cof6duas4b3q2fy6swua')
+      ).not.toThrow();
       expect(() => tool['validateCid']('bafkreiabcd1234')).not.toThrow();
       expect(() => tool['validateCid']('')).toThrow();
     });
@@ -144,5 +146,31 @@ describe('BaseTool', () => {
       expect(() => tool['validateISO8601Date']('')).toThrow();
     });
   });
-});
 
+  describe('parseAtUri', () => {
+    let tool: TestTool;
+    beforeEach(() => {
+      tool = new TestTool(createMockAtpClient());
+    });
+
+    it('parses a well-formed AT URI into repo/collection/rkey', () => {
+      const parsed = tool['parseAtUri']('at://did:plc:abc/app.bsky.feed.post/xyz');
+      expect(parsed).toEqual({
+        repo: 'did:plc:abc',
+        collection: 'app.bsky.feed.post',
+        rkey: 'xyz',
+      });
+    });
+
+    it('throws on a non-at:// URI', () => {
+      expect(() => tool['parseAtUri']('https://example.com/x')).toThrow(/Invalid AT Protocol URI/);
+    });
+
+    it('throws on a malformed AT URI missing components', () => {
+      expect(() => tool['parseAtUri']('at://did:plc:abc')).toThrow(/Malformed AT Protocol URI/);
+      expect(() => tool['parseAtUri']('at://did:plc:abc/coll')).toThrow(
+        /Malformed AT Protocol URI/
+      );
+    });
+  });
+});

--- a/src/tools/implementations/__tests__/base-tool.test.ts
+++ b/src/tools/implementations/__tests__/base-tool.test.ts
@@ -5,6 +5,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { BaseTool, ToolAuthMode } from '../base-tool.js';
 import type { AtpClient } from '../../../utils/atp-client.js';
+import { RateLimitError } from '../../../types/index.js';
 import { z } from 'zod';
 
 // Create a concrete implementation for testing
@@ -137,6 +138,11 @@ describe('BaseTool', () => {
       expect(() => tool['validateActor']('did:plc:abc123')).not.toThrow();
       expect(() => tool['validateActor']('user.bsky.social')).not.toThrow();
       expect(() => tool['validateActor']('')).toThrow();
+      // Tightened: traversal/scheme-like junk must NOT be accepted as a handle.
+      expect(() => tool['validateActor']('../../etc/passwd')).toThrow();
+      expect(() => tool['validateActor']('javascript:alert(1)//.x')).toThrow();
+      expect(() => tool['validateActor']('has spaces.com')).toThrow();
+      expect(() => tool['validateActor']('nodot')).toThrow();
     });
 
     it('should validate ISO8601 date format', () => {
@@ -171,6 +177,27 @@ describe('BaseTool', () => {
       expect(() => tool['parseAtUri']('at://did:plc:abc/coll')).toThrow(
         /Malformed AT Protocol URI/
       );
+    });
+  });
+
+  describe('getCidFromUri error propagation', () => {
+    it('preserves a typed error (RateLimitError) instead of collapsing it to a generic Error', async () => {
+      const rateLimited = {
+        isAuthenticated: vi.fn().mockReturnValue(true),
+        hasCredentials: vi.fn().mockReturnValue(true),
+        getAgent: vi.fn().mockReturnValue({ com: { atproto: { repo: { getRecord: vi.fn() } } } }),
+        executeAuthenticatedRequest: vi.fn().mockResolvedValue({
+          success: false,
+          error: new RateLimitError('Rate limit exceeded', 30),
+        }),
+      } as unknown as AtpClient;
+      const tool = new TestTool(rateLimited);
+
+      // The original RateLimitError must survive so the server maps it correctly
+      // (a generic Error would be reported as a plain internal failure).
+      await expect(
+        tool['getCidFromUri']('at://did:plc:abc/app.bsky.feed.post/xyz')
+      ).rejects.toBeInstanceOf(RateLimitError);
     });
   });
 });

--- a/src/tools/implementations/__tests__/base-tool.test.ts
+++ b/src/tools/implementations/__tests__/base-tool.test.ts
@@ -137,6 +137,9 @@ describe('BaseTool', () => {
     it('should validate actor (DID or handle)', () => {
       expect(() => tool['validateActor']('did:plc:abc123')).not.toThrow();
       expect(() => tool['validateActor']('user.bsky.social')).not.toThrow();
+      // did:web identifiers legitimately contain colons (host:port:path segments).
+      expect(() => tool['validateActor']('did:web:example.com')).not.toThrow();
+      expect(() => tool['validateActor']('did:web:example.com:user:alice')).not.toThrow();
       expect(() => tool['validateActor']('')).toThrow();
       // Tightened: traversal/scheme-like junk must NOT be accepted as a handle.
       expect(() => tool['validateActor']('../../etc/passwd')).toThrow();

--- a/src/tools/implementations/advanced-social-tools.ts
+++ b/src/tools/implementations/advanced-social-tools.ts
@@ -3,7 +3,7 @@
  */
 
 import { z } from 'zod';
-import { BaseTool } from './base-tool.js';
+import { BaseTool, ToolAuthMode } from './base-tool.js';
 import type { AtpClient } from '../../utils/atp-client.js';
 
 const CreateListSchema = z.object({
@@ -313,7 +313,9 @@ export class GetListTool extends BaseTool {
   };
 
   constructor(atpClient: AtpClient) {
-    super(atpClient, 'GetList');
+    // Reading a list works against the public AppView; it just returns richer
+    // viewer state when authenticated.
+    super(atpClient, 'GetList', ToolAuthMode.ENHANCED);
   }
 
   protected async execute(params: { listUri: string; limit?: number; cursor?: string }): Promise<{
@@ -379,7 +381,9 @@ export class GetListTool extends BaseTool {
             handle: response.data.list.creator.handle,
             displayName: response.data.list.creator.displayName,
           },
-          itemCount: response.data.items.length,
+          // The list view carries the true member count; items.length is only the
+          // current page, so prefer listItemCount and fall back when it is absent.
+          itemCount: response.data.list.listItemCount ?? response.data.items.length,
         },
         items: response.data.items.map((item: any) => ({
           uri: item.uri,
@@ -408,7 +412,8 @@ export class GetThreadTool extends BaseTool {
   };
 
   constructor(atpClient: AtpClient) {
-    super(atpClient, 'GetThread');
+    // Fetching a public thread does not require authentication.
+    super(atpClient, 'GetThread', ToolAuthMode.ENHANCED);
   }
 
   protected async execute(params: { uri: string; depth?: number; parentHeight?: number }): Promise<{
@@ -509,7 +514,8 @@ export class GetCustomFeedTool extends BaseTool {
   };
 
   constructor(atpClient: AtpClient) {
-    super(atpClient, 'GetCustomFeed');
+    // Public custom feeds are readable without authentication.
+    super(atpClient, 'GetCustomFeed', ToolAuthMode.ENHANCED);
   }
 
   protected async execute(params: { feedUri: string; limit?: number; cursor?: string }): Promise<{

--- a/src/tools/implementations/advanced-social-tools.ts
+++ b/src/tools/implementations/advanced-social-tools.ts
@@ -518,7 +518,9 @@ export class GetCustomFeedTool extends BaseTool {
       uri: string;
       displayName?: string;
       description?: string;
-      creator: {
+      // Optional: only present when the feed-generator metadata could be fetched
+      // (app.bsky.feed.getFeed does not return it; getFeedGenerator does).
+      creator?: {
         did: string;
         handle: string;
         displayName?: string;
@@ -569,17 +571,41 @@ export class GetCustomFeedTool extends BaseTool {
         postCount: response.data.feed.length,
       });
 
-      // Extract feed metadata safely
+      // app.bsky.feed.getFeed returns only { feed, cursor } — it carries no
+      // displayName/description/creator. Fetch that metadata separately (best
+      // effort) via getFeedGenerator; if it fails (e.g. the URI is not a feed
+      // generator, or the generator is offline) we return just the URI rather
+      // than fabricating always-undefined fields.
       const feedData = response.data.feed as any[];
-      const feedMeta = response.data as any;
+      let feedMeta: { displayName?: string; description?: string; creator?: any } = {};
+      try {
+        const genResponse = await this.executeAtpOperation(
+          async () => {
+            const agent = this.atpClient.getAgent();
+            return await agent.app.bsky.feed.getFeedGenerator({ feed: params.feedUri });
+          },
+          'getFeedGenerator',
+          { feedUri: params.feedUri }
+        );
+        const view = (genResponse.data as any).view;
+        if (view) {
+          feedMeta = {
+            displayName: view.displayName,
+            description: view.description,
+            creator: view.creator,
+          };
+        }
+      } catch (metaError) {
+        this.logger.debug('Could not fetch feed generator metadata', metaError);
+      }
 
       return {
         success: true,
         feed: {
           uri: params.feedUri,
-          displayName: feedMeta.displayName,
-          description: feedMeta.description,
-          creator: feedMeta.creator,
+          ...(feedMeta.displayName != null && { displayName: feedMeta.displayName }),
+          ...(feedMeta.description != null && { description: feedMeta.description }),
+          ...(feedMeta.creator != null && { creator: feedMeta.creator }),
         },
         posts: feedData.map((item: any) => ({
           uri: item.post.uri,

--- a/src/tools/implementations/analytics-tools.ts
+++ b/src/tools/implementations/analytics-tools.ts
@@ -105,12 +105,22 @@ export class AnalyzeNetworkTool extends BaseTool {
       let topFollowers: any[] = [];
       let topFollows: any[] = [];
       let mutualConnectionsCount = 0;
+      // Full DID set of the sampled followers (up to maxSampleSize), kept so
+      // mutual-connection counting intersects the *entire* sample rather than
+      // just the top-10 ranked slice.
+      let followerDidSet = new Set<string>();
 
       if (params.includeFollowers && followersCount > 0) {
         const followersResponse = await this.executeAtpOperation(
           async () => agent.getFollowers({ actor, limit: params.maxSampleSize }),
           'getFollowers',
           { actor, limit: params.maxSampleSize }
+        );
+
+        // Capture the full sampled follower DID set for mutual-connection
+        // counting before we rank/truncate to the top 10.
+        followerDidSet = new Set(
+          (followersResponse.data.followers as any[]).map(f => f.did).filter(Boolean)
         );
 
         // getFollowers returns ProfileView entries WITHOUT followersCount, so we
@@ -148,10 +158,14 @@ export class AnalyzeNetworkTool extends BaseTool {
             followersCount: f.followersCount ?? 0,
           }));
 
-        // Calculate mutual connections
-        if (params.includeFollowers && topFollowers.length > 0) {
-          const followerDids = new Set(topFollowers.map(f => f.did));
-          mutualConnectionsCount = topFollows.filter(f => followerDids.has(f.did)).length;
+        // Calculate mutual connections over the FULL sampled sets (not the
+        // top-10 ranked slices, which would cap the count at 10 and bias it to
+        // high-follower accounts). This is the overlap within the sampled
+        // followers/follows (each up to maxSampleSize), not the lifetime total.
+        if (params.includeFollowers && followerDidSet.size > 0) {
+          mutualConnectionsCount = (followsResponse.data.follows as any[]).filter(f =>
+            followerDidSet.has(f.did)
+          ).length;
         }
       }
 

--- a/src/tools/implementations/analytics-tools.ts
+++ b/src/tools/implementations/analytics-tools.ts
@@ -785,50 +785,52 @@ export class FindInfluentialUsersTool extends BaseTool {
         };
       }
 
-      // Get profiles for all authors
-      const users: any[] = [];
-
-      for (const did of Array.from(authorDids).slice(0, params.maxResults! * 2)) {
+      // Hydrate author profiles in batches via getProfiles (up to 25 actors per
+      // call) instead of one sequential getProfile round-trip per author.
+      const targetDids = Array.from(authorDids).slice(0, params.maxResults! * 2);
+      const profiles: any[] = [];
+      for (let i = 0; i < targetDids.length; i += 25) {
+        const chunk = targetDids.slice(i, i + 25);
         try {
-          const profileResponse = await this.executeAtpOperation(
-            async () => agent.getProfile({ actor: did }),
-            'getProfile',
-            { actor: did }
+          const resp = await this.executeAtpOperation(
+            async () => agent.getProfiles({ actors: chunk }),
+            'getProfiles',
+            { count: chunk.length }
+          );
+          profiles.push(...((resp.data.profiles as any[]) ?? []));
+        } catch {
+          this.logger.warn('Failed to fetch a profile chunk', { count: chunk.length });
+        }
+      }
+
+      const users: any[] = [];
+      for (const profile of profiles) {
+        const followersCount = profile.followersCount || 0;
+
+        // Filter by minimum followers
+        if (followersCount >= params.minFollowers!) {
+          const influenceScore = this.calculateInfluenceScore(
+            followersCount,
+            profile.followsCount || 0,
+            profile.postsCount || 0
           );
 
-          const profile = profileResponse.data;
-          const followersCount = profile.followersCount || 0;
+          // Relevance = how many of the matched posts are from this author.
+          const relevanceScore = searchResponse.data.posts.filter(
+            p => p.author.did === profile.did
+          ).length;
 
-          // Filter by minimum followers
-          if (followersCount >= params.minFollowers!) {
-            // Calculate influence score
-            const influenceScore = this.calculateInfluenceScore(
-              followersCount,
-              profile.followsCount || 0,
-              profile.postsCount || 0
-            );
-
-            // Calculate relevance score based on how many posts match the query
-            const relevantPosts = searchResponse.data.posts.filter(
-              p => p.author.did === did
-            ).length;
-            const relevanceScore = relevantPosts;
-
-            users.push({
-              did: profile.did,
-              handle: profile.handle,
-              displayName: profile.displayName,
-              description: profile.description,
-              followersCount,
-              followsCount: profile.followsCount || 0,
-              postsCount: profile.postsCount || 0,
-              influenceScore,
-              relevanceScore,
-            });
-          }
-        } catch {
-          // Skip users that can't be fetched
-          this.logger.warn('Failed to fetch profile', { did });
+          users.push({
+            did: profile.did,
+            handle: profile.handle,
+            displayName: profile.displayName,
+            description: profile.description,
+            followersCount,
+            followsCount: profile.followsCount || 0,
+            postsCount: profile.postsCount || 0,
+            influenceScore,
+            relevanceScore,
+          });
         }
       }
 

--- a/src/tools/implementations/base-tool.ts
+++ b/src/tools/implementations/base-tool.ts
@@ -323,6 +323,21 @@ export abstract class BaseTool implements IMcpTool {
   }
 
   /**
+   * Upload a Blob to the user's PDS and return the blob ref payload.
+   */
+  protected async uploadBlob(blob: Blob): Promise<{ blob: any }> {
+    return await this.executeAtpOperation(
+      async () => {
+        const agent = this.atpClient.getAgent();
+        const response = await agent.uploadBlob(blob, { encoding: blob.type });
+        return response.data;
+      },
+      'uploadBlob',
+      { blobSize: blob.size, blobType: blob.type }
+    );
+  }
+
+  /**
    * Resolve the CID of the record referenced by an AT Protocol URI by fetching
    * the record. Throws a clear error if the URI is malformed or has no CID.
    */

--- a/src/tools/implementations/base-tool.ts
+++ b/src/tools/implementations/base-tool.ts
@@ -9,7 +9,12 @@ import { RichText } from '@atproto/api';
 import type { AtpClient } from '../../utils/atp-client.js';
 import type { IMcpTool } from '../index.js';
 import { Logger } from '../../utils/logger.js';
-import { AtpError, AuthenticationError, ValidationError } from '../../types/index.js';
+import {
+  AtpError,
+  AuthenticationError,
+  type IAtpPost,
+  ValidationError,
+} from '../../types/index.js';
 
 /**
  * Tool authentication requirements
@@ -277,18 +282,36 @@ export abstract class BaseTool implements IMcpTool {
     if (!actor || typeof actor !== 'string') {
       throw new ValidationError('Actor must be a non-empty string');
     }
+    if (actor.length > 2048) {
+      throw new ValidationError('Actor is too long', 'actor', actor);
+    }
 
-    // Basic validation for DID or handle format
-    const isDid = actor.startsWith('did:');
-    const isHandle = actor.includes('.') && !actor.startsWith('http');
-
-    if (!isDid && !isHandle) {
+    // A DID (did:method:id) or a DNS-style handle. The previous "contains a dot"
+    // heuristic accepted traversal/scheme-like junk (e.g. "../../etc",
+    // "javascript:alert(1)//.x") as handles; validate the real structure instead.
+    const isDid = /^did:[a-z0-9]+:[a-zA-Z0-9._%-]+$/.test(actor);
+    if (!isDid && !this.isValidHandle(actor)) {
       throw new ValidationError(
         'Actor must be a valid DID (did:...) or handle (user.domain.com)',
         'actor',
         actor
       );
     }
+  }
+
+  /**
+   * Validate a DNS-style AT Protocol handle. Splits on '.' and checks each label
+   * independently so the check is linear (no catastrophic-backtracking risk) — a
+   * valid handle has at least two labels, each a DNS label (1-63 chars,
+   * alphanumeric with optional internal hyphens).
+   */
+  private isValidHandle(handle: string): boolean {
+    const labels = handle.split('.');
+    if (labels.length < 2) {
+      return false;
+    }
+    const label = /^[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?$/;
+    return labels.every(part => label.test(part));
   }
 
   /**
@@ -364,6 +387,12 @@ export abstract class BaseTool implements IMcpTool {
       return cid;
     } catch (error) {
       this.logger.error('Failed to resolve CID from URI', error, { uri });
+      // Preserve typed errors (AuthenticationError, RateLimitError, ValidationError,
+      // and other AtpErrors) so the server maps them to the correct MCP error code
+      // and the caller keeps the original cause. Only wrap genuinely unknown errors.
+      if (error instanceof AtpError || error instanceof ValidationError) {
+        throw error;
+      }
       throw new Error(
         `Could not resolve CID from URI ${uri}: ${
           error instanceof Error ? error.message : 'Unknown error'
@@ -422,6 +451,58 @@ export abstract class BaseTool implements IMcpTool {
         dateString
       );
     }
+  }
+
+  /**
+   * Map an app.bsky.feed.defs#postView (as returned by searchPosts/getTimeline/
+   * getAuthorFeed) into the server's normalized IAtpPost shape. Shared so the
+   * search and timeline tools do not each carry an identical copy.
+   */
+  protected transformPostView(postData: any): IAtpPost {
+    return {
+      uri: postData.uri,
+      cid: postData.cid,
+      author: {
+        did: postData.author.did,
+        handle: postData.author.handle,
+        displayName: postData.author.displayName,
+        description: postData.author.description,
+        avatar: postData.author.avatar,
+        followersCount: postData.author.followersCount,
+        followsCount: postData.author.followsCount,
+        postsCount: postData.author.postsCount,
+      },
+      record: {
+        text: postData.record.text || '',
+        createdAt: postData.record.createdAt,
+        reply: postData.record.reply
+          ? {
+              root: {
+                uri: postData.record.reply.root.uri,
+                cid: postData.record.reply.root.cid,
+              },
+              parent: {
+                uri: postData.record.reply.parent.uri,
+                cid: postData.record.reply.parent.cid,
+              },
+            }
+          : undefined,
+        embed: postData.record.embed,
+        langs: postData.record.langs,
+        labels: postData.record.labels,
+        tags: postData.record.tags,
+      },
+      replyCount: postData.replyCount,
+      repostCount: postData.repostCount,
+      likeCount: postData.likeCount,
+      indexedAt: postData.indexedAt,
+      viewer: postData.viewer
+        ? {
+            repost: postData.viewer.repost,
+            like: postData.viewer.like,
+          }
+        : undefined,
+    };
   }
 
   /**

--- a/src/tools/implementations/base-tool.ts
+++ b/src/tools/implementations/base-tool.ts
@@ -289,7 +289,9 @@ export abstract class BaseTool implements IMcpTool {
     // A DID (did:method:id) or a DNS-style handle. The previous "contains a dot"
     // heuristic accepted traversal/scheme-like junk (e.g. "../../etc",
     // "javascript:alert(1)//.x") as handles; validate the real structure instead.
-    const isDid = /^did:[a-z0-9]+:[a-zA-Z0-9._%-]+$/.test(actor);
+    // The identifier portion allows ':' so did:web host:port:path segments
+    // (e.g. did:web:example.com:user:alice) are not rejected.
+    const isDid = /^did:[a-z0-9]+:[a-zA-Z0-9._:%-]+$/.test(actor);
     if (!isDid && !this.isValidHandle(actor)) {
       throw new ValidationError(
         'Actor must be a valid DID (did:...) or handle (user.domain.com)',

--- a/src/tools/implementations/base-tool.ts
+++ b/src/tools/implementations/base-tool.ts
@@ -305,6 +305,59 @@ export abstract class BaseTool implements IMcpTool {
   }
 
   /**
+   * Parse an AT Protocol URI (at://<repo>/<collection>/<rkey>) into its parts.
+   * Throws if the URI is malformed.
+   */
+  protected parseAtUri(uri: string): { repo: string; collection: string; rkey: string } {
+    if (!uri?.startsWith('at://')) {
+      throw new Error(`Invalid AT Protocol URI: ${uri}`);
+    }
+
+    const parts = uri.slice('at://'.length).split('/');
+    const [repo, collection, rkey] = parts;
+    if (parts.length < 3 || !repo || !collection || !rkey) {
+      throw new Error(`Malformed AT Protocol URI: ${uri}`);
+    }
+
+    return { repo, collection, rkey };
+  }
+
+  /**
+   * Resolve the CID of the record referenced by an AT Protocol URI by fetching
+   * the record. Throws a clear error if the URI is malformed or has no CID.
+   */
+  protected async getCidFromUri(uri: string): Promise<string> {
+    try {
+      this.logger.debug('Resolving CID from URI', { uri });
+      const { repo, collection, rkey } = this.parseAtUri(uri);
+
+      const response = await this.executeAtpOperation(
+        async () => {
+          const agent = this.atpClient.getAgent();
+          return await agent.com.atproto.repo.getRecord({ repo, collection, rkey });
+        },
+        'getRecord',
+        { uri, repo, collection, rkey }
+      );
+
+      const cid = response.data.cid;
+      if (!cid) {
+        throw new Error(`No CID found in record response for URI: ${uri}`);
+      }
+
+      this.logger.debug('Successfully resolved CID from URI', { uri, cid });
+      return cid;
+    } catch (error) {
+      this.logger.error('Failed to resolve CID from URI', error, { uri });
+      throw new Error(
+        `Could not resolve CID from URI ${uri}: ${
+          error instanceof Error ? error.message : 'Unknown error'
+        }`
+      );
+    }
+  }
+
+  /**
    * Validate CID
    */
   protected validateCid(cid: string): void {

--- a/src/tools/implementations/batch-operations-tools.ts
+++ b/src/tools/implementations/batch-operations-tools.ts
@@ -415,42 +415,7 @@ export class BatchLikeTool extends BaseTool {
     }
   }
 
-  /**
-   * Get CID from AT Protocol URI by fetching the record
-   */
-  private async getCidFromUri(uri: string): Promise<string> {
-    const response = await this.executeAtpOperation(
-      async () => {
-        const agent = this.atpClient.getAgent();
-        const uriParts = uri.replace('at://', '').split('/');
-        if (uriParts.length < 3) {
-          throw new Error(`Invalid AT URI format: ${uri}`);
-        }
-
-        const did = uriParts[0];
-        const collection = uriParts[1];
-        const rkey = uriParts[2];
-
-        if (!did || !collection || !rkey) {
-          throw new Error(`Invalid AT URI components: ${uri}`);
-        }
-
-        return await agent.com.atproto.repo.getRecord({
-          repo: did,
-          collection,
-          rkey,
-        });
-      },
-      'getRecord',
-      { uri }
-    );
-
-    const cid = response.data.cid;
-    if (!cid) {
-      throw new Error(`No CID found for URI: ${uri}`);
-    }
-    return cid;
-  }
+  // getCidFromUri is provided by BaseTool.
 }
 
 /**
@@ -655,40 +620,5 @@ export class BatchRepostTool extends BaseTool {
     }
   }
 
-  /**
-   * Get CID from AT Protocol URI by fetching the record
-   */
-  private async getCidFromUri(uri: string): Promise<string> {
-    const response = await this.executeAtpOperation(
-      async () => {
-        const agent = this.atpClient.getAgent();
-        const uriParts = uri.replace('at://', '').split('/');
-        if (uriParts.length < 3) {
-          throw new Error(`Invalid AT URI format: ${uri}`);
-        }
-
-        const did = uriParts[0];
-        const collection = uriParts[1];
-        const rkey = uriParts[2];
-
-        if (!did || !collection || !rkey) {
-          throw new Error(`Invalid AT URI components: ${uri}`);
-        }
-
-        return await agent.com.atproto.repo.getRecord({
-          repo: did,
-          collection,
-          rkey,
-        });
-      },
-      'getRecord',
-      { uri }
-    );
-
-    const cid = response.data.cid;
-    if (!cid) {
-      throw new Error(`No CID found for URI: ${uri}`);
-    }
-    return cid;
-  }
+  // getCidFromUri is provided by BaseTool.
 }

--- a/src/tools/implementations/content-discovery-tools.ts
+++ b/src/tools/implementations/content-discovery-tools.ts
@@ -315,17 +315,6 @@ export class FindSimilarUsersTool extends BaseTool {
     }
   }
 
-  private extractTopics(posts: any[]): Set<string> {
-    const topics = new Set<string>();
-    for (const post of posts) {
-      const text = post.record?.text || '';
-      // Extract hashtags
-      const hashtags = text.match(/#\w+/g) || [];
-      hashtags.forEach((tag: string) => topics.add(tag.toLowerCase()));
-    }
-    return topics;
-  }
-
   private calculateFollowerRatioSimilarity(profile1: any, profile2: any): number {
     const ratio1 = (profile1.followersCount || 0) / Math.max(profile1.followsCount || 1, 1);
     const ratio2 = (profile2.followersCount || 0) / Math.max(profile2.followsCount || 1, 1);

--- a/src/tools/implementations/content-discovery-tools.ts
+++ b/src/tools/implementations/content-discovery-tools.ts
@@ -126,21 +126,13 @@ export class FindSimilarUsersTool extends BaseTool {
 
       const baseFollows = followsResponse.data.follows as any[];
 
-      // Get base user's recent posts for content analysis
-      const postsResponse = await this.executeAtpOperation(
-        async () => agent.getAuthorFeed({ actor: params.actor, limit: 30 }),
-        'getAuthorFeed',
-        { actor: params.actor, limit: 30 }
-      );
-
-      const basePosts = postsResponse.data.feed.map((item: any) => item.post);
-      const baseTopics = this.extractTopics(basePosts);
+      // NOTE: this tool ranks by follow-graph overlap only — it does NOT analyze
+      // content topics. The previous getAuthorFeed fetch + topic extraction was a
+      // wasted network round-trip whose result was never used, so it is omitted.
 
       this.logger.info('Base user data collected', {
         followersCount: baseFollowers.size,
         followsCount: baseFollows.length,
-        postsCount: basePosts.length,
-        topicsCount: baseTopics.size,
       });
 
       // Analyze follows to find similar users
@@ -434,7 +426,13 @@ export class RecommendContentTool extends BaseTool {
         { limit: 100 }
       );
 
-      const timelinePosts = timelineResponse.data.feed.map((item: any) => item.post);
+      // The repost indicator lives on the feed item's `reason`
+      // (app.bsky.feed.defs#reasonRepost), not on the post record — preserve it so
+      // excludeReposts can actually filter reposts.
+      const timelinePosts = timelineResponse.data.feed.map((item: any) => ({
+        ...item.post,
+        __isRepost: item.reason?.$type === 'app.bsky.feed.defs#reasonRepost',
+      }));
 
       // Get user's recent likes to understand preferences
       const likedTopics = new Set<string>();
@@ -471,8 +469,8 @@ export class RecommendContentTool extends BaseTool {
         // Skip if already liked
         if (postData.viewer?.like) continue;
 
-        // Skip reposts if requested
-        if (params.excludeReposts && postData.record?.repost) continue;
+        // Skip reposts if requested (flag derived from the feed item's reason).
+        if (params.excludeReposts && postData.__isRepost) continue;
 
         // Check age
         const postAge = now.getTime() - new Date(postData.indexedAt).getTime();

--- a/src/tools/implementations/content-management-tools.ts
+++ b/src/tools/implementations/content-management-tools.ts
@@ -5,7 +5,12 @@
 import { z } from 'zod';
 import { BaseTool } from './base-tool.js';
 import type { AtpClient } from '../../utils/atp-client.js';
-import type { ATURI, IDeletePostParams, IUpdateProfileParams } from '../../types/index.js';
+import {
+  type ATURI,
+  type IDeletePostParams,
+  type IUpdateProfileParams,
+  ValidationError,
+} from '../../types/index.js';
 
 /**
  * Zod schema for delete post parameters
@@ -57,22 +62,21 @@ export class DeletePostTool extends BaseTool {
       // Verify the post exists and belongs to the current user
       await this.verifyPostOwnership(params.uri);
 
-      // Delete the post record
+      // Delete the post record. The repo is pinned to the authenticated user's own
+      // DID (verifyPostOwnership already confirmed the URI's authority matches) and
+      // the collection is pinned to app.bsky.feed.post so a non-post URI cannot
+      // delete an arbitrary record type.
+      const { rkey } = this.parseAtUri(params.uri);
       await this.executeAtpOperation(
         async () => {
           const agent = this.atpClient.getAgent();
-          const uriParts = params.uri.replace('at://', '').split('/');
-          const did = uriParts[0];
-          const collection = uriParts[1];
-          const rkey = uriParts[2];
-
-          if (!did || !collection || !rkey) {
-            throw new Error(`Invalid AT URI format: ${params.uri}`);
+          const repo = agent.session?.did;
+          if (!repo) {
+            throw new Error('User session not available');
           }
-
           return await agent.com.atproto.repo.deleteRecord({
-            repo: did,
-            collection,
+            repo,
+            collection: 'app.bsky.feed.post',
             rkey,
           });
         },
@@ -109,30 +113,28 @@ export class DeletePostTool extends BaseTool {
         throw new Error('User session not available');
       }
 
-      // Extract DID from URI
-      const uriParts = uri.replace('at://', '').split('/');
-      const postOwnerDid = uriParts[0];
+      // Parse and pin the collection: delete_post must only ever delete a post
+      // record, never some other record type named by an untrusted URI.
+      const { repo: postOwnerDid, collection, rkey } = this.parseAtUri(uri);
+      if (collection !== 'app.bsky.feed.post') {
+        throw new ValidationError(
+          `delete_post can only delete post records (collection "${collection}" is not app.bsky.feed.post)`,
+          'uri',
+          uri
+        );
+      }
 
       if (postOwnerDid !== currentUserDid) {
         throw new Error('Cannot delete post: post belongs to another user');
       }
 
-      // Verify the post exists
-      const collection = uriParts[1];
-      const rkey = uriParts[2];
-
       await this.executeAtpOperation(
-        async () => {
-          if (!collection || !rkey) {
-            throw new Error(`Invalid AT URI format: ${uri}`);
-          }
-
-          return await agent.com.atproto.repo.getRecord({
+        async () =>
+          await agent.com.atproto.repo.getRecord({
             repo: postOwnerDid,
             collection,
             rkey,
-          });
-        },
+          }),
         'verifyPost',
         { uri }
       );
@@ -177,8 +179,8 @@ export class UpdateProfileTool extends BaseTool {
         hasBanner: !!params.banner,
       });
 
-      // Get current profile to merge with updates
-      const currentProfile = await this.getCurrentProfile();
+      // Get current profile (and its CID) to merge with updates.
+      const { value: currentProfile, cid: currentCid } = await this.getCurrentProfile();
 
       // Build updated profile record. Start from the EXISTING record so fields
       // this tool does not manage (pinnedPost, createdAt, pronouns, labels, etc.)
@@ -232,6 +234,9 @@ export class UpdateProfileTool extends BaseTool {
             collection: 'app.bsky.actor.profile',
             rkey: 'self',
             record: updatedProfile,
+            // Compare-and-swap against the CID we read so a concurrent profile
+            // update is detected (InvalidSwap) instead of being silently clobbered.
+            ...(currentCid ? { swapRecord: currentCid } : {}),
           });
         },
         'updateProfile',
@@ -260,9 +265,10 @@ export class UpdateProfileTool extends BaseTool {
   }
 
   /**
-   * Get current profile record
+   * Get the current profile record and its CID (the CID enables a compare-and-swap
+   * on write). Returns an empty value with no CID when no profile exists yet.
    */
-  private async getCurrentProfile(): Promise<any> {
+  private async getCurrentProfile(): Promise<{ value: any; cid?: string }> {
     try {
       const response = await this.executeAtpOperation(
         async () => {
@@ -283,11 +289,15 @@ export class UpdateProfileTool extends BaseTool {
         {}
       );
 
-      return response.data.value || {};
+      return {
+        value: response.data.value || {},
+        ...(response.data.cid ? { cid: response.data.cid } : {}),
+      };
     } catch {
-      // If profile doesn't exist, return empty object
+      // If profile doesn't exist, return empty value (a first-time create has no
+      // prior CID to swap against).
       this.logger.debug('No existing profile found, creating new one');
-      return {};
+      return { value: {} };
     }
   }
 

--- a/src/tools/implementations/content-management-tools.ts
+++ b/src/tools/implementations/content-management-tools.ts
@@ -291,20 +291,5 @@ export class UpdateProfileTool extends BaseTool {
     }
   }
 
-  /**
-   * Upload a blob to AT Protocol
-   */
-  private async uploadBlob(blob: Blob): Promise<{ blob: any }> {
-    return await this.executeAtpOperation(
-      async () => {
-        const agent = this.atpClient.getAgent();
-        const response = await agent.uploadBlob(blob, {
-          encoding: blob.type,
-        });
-        return response.data;
-      },
-      'uploadBlob',
-      { blobSize: blob.size, blobType: blob.type }
-    );
-  }
+  // uploadBlob is provided by BaseTool.
 }

--- a/src/tools/implementations/create-post-tool.ts
+++ b/src/tools/implementations/create-post-tool.ts
@@ -172,63 +172,7 @@ export class CreatePostTool extends BaseTool {
     }
   }
 
-  /**
-   * Get CID from AT Protocol URI by resolving the record
-   *
-   * AT Protocol URIs have the format: at://did:plc:xxx/collection/rkey
-   * This method fetches the actual record to get its CID
-   */
-  private async getCidFromUri(uri: string): Promise<string> {
-    try {
-      this.logger.debug('Resolving CID from URI', { uri });
-
-      // Parse the AT URI: at://did:plc:xxx/collection/rkey
-      if (!uri.startsWith('at://')) {
-        throw new Error(`Invalid AT Protocol URI: ${uri}`);
-      }
-
-      const uriWithoutProtocol = uri.slice(5); // Remove 'at://'
-      const parts = uriWithoutProtocol.split('/');
-
-      if (parts.length < 3) {
-        throw new Error(`Malformed AT Protocol URI: ${uri}`);
-      }
-
-      const repo = parts[0]!; // DID (guaranteed by length check)
-      const collection = parts[1]!; // e.g., 'app.bsky.feed.post' (guaranteed by length check)
-      const rkey = parts[2]!; // Record key (guaranteed by length check)
-
-      // Fetch the record from AT Protocol to get its CID
-      const response = await this.executeAtpOperation(
-        async () => {
-          const agent = this.atpClient.getAgent();
-          return await agent.com.atproto.repo.getRecord({
-            repo,
-            collection,
-            rkey,
-          });
-        },
-        'getRecord',
-        { uri, repo, collection, rkey }
-      );
-
-      if (!response.data.cid) {
-        throw new Error(`No CID found in record response for URI: ${uri}`);
-      }
-
-      this.logger.debug('Successfully resolved CID from URI', {
-        uri,
-        cid: response.data.cid,
-      });
-
-      return response.data.cid;
-    } catch (error) {
-      this.logger.error('Failed to resolve CID from URI', error, { uri });
-      throw new Error(
-        `Could not resolve CID from URI ${uri}: ${error instanceof Error ? error.message : 'Unknown error'}`
-      );
-    }
-  }
+  // getCidFromUri is provided by BaseTool (shared by reply/batch tools).
 
   /**
    * Process embed data for the post

--- a/src/tools/implementations/create-post-tool.ts
+++ b/src/tools/implementations/create-post-tool.ts
@@ -233,20 +233,5 @@ export class CreatePostTool extends BaseTool {
     return undefined;
   }
 
-  /**
-   * Upload a blob to AT Protocol
-   */
-  private async uploadBlob(blob: Blob): Promise<{ blob: any }> {
-    return await this.executeAtpOperation(
-      async () => {
-        const agent = this.atpClient.getAgent();
-        const response = await agent.uploadBlob(blob, {
-          encoding: blob.type,
-        });
-        return response.data;
-      },
-      'uploadBlob',
-      { blobSize: blob.size, blobType: blob.type }
-    );
-  }
+  // uploadBlob is provided by BaseTool.
 }

--- a/src/tools/implementations/follow-user-tool.ts
+++ b/src/tools/implementations/follow-user-tool.ts
@@ -51,20 +51,22 @@ export class FollowUserTool extends BaseTool {
       // Validate the actor identifier
       this.validateActor(params.actor);
 
-      // Resolve the actor to get their DID and profile info
+      // Resolve the actor to get their DID, profile info, and the authoritative
+      // "am I already following this user" signal (viewer.following).
       const userProfile = await this.resolveActor(params.actor);
 
-      // Check if already following this user
-      const existingFollow = await this.checkExistingFollow(userProfile.did);
-      if (existingFollow) {
+      // Check if already following this user. viewer.following is the
+      // authoritative signal — unlike a listRecords scan, it does not miss
+      // follows beyond the first page on accounts that follow >100 users.
+      if (userProfile.followingUri) {
         this.logger.info('User is already being followed', {
           actor: params.actor,
-          followUri: existingFollow.uri,
+          followUri: userProfile.followingUri,
         });
 
         return {
-          uri: existingFollow.uri as ATURI,
-          cid: existingFollow.cid as CID,
+          uri: userProfile.followingUri as ATURI,
+          cid: '' as CID,
           success: true,
           message: 'User was already being followed',
           followedUser: {
@@ -122,9 +124,16 @@ export class FollowUserTool extends BaseTool {
   }
 
   /**
-   * Resolve actor identifier to DID and profile information
+   * Resolve actor identifier to DID, profile information, and existing-follow state.
+   *
+   * `viewer.following` (the follow record's AT-URI when the authenticated user
+   * already follows this actor) is the authoritative duplicate signal — unlike
+   * a listRecords scan it does not miss follows beyond the first page on
+   * accounts that follow >100 users.
    */
-  private async resolveActor(actor: string): Promise<{ did: DID; handle?: string }> {
+  private async resolveActor(
+    actor: string
+  ): Promise<{ did: DID; handle?: string; followingUri?: string }> {
     try {
       const response = await this.executeAtpOperation(
         async () => {
@@ -138,55 +147,13 @@ export class FollowUserTool extends BaseTool {
       return {
         did: response.data.did as DID,
         ...(response.data.handle && { handle: response.data.handle }),
+        ...(response.data.viewer?.following && {
+          followingUri: response.data.viewer.following,
+        }),
       };
     } catch (error) {
       this.logger.error('Failed to resolve actor', error, { actor });
       throw error;
-    }
-  }
-
-  /**
-   * Check if the user is already being followed
-   */
-  private async checkExistingFollow(
-    targetDid: string
-  ): Promise<{ uri: string; cid: string } | null> {
-    try {
-      const response = await this.executeAtpOperation(
-        async () => {
-          const agent = this.atpClient.getAgent();
-          const userDid = agent.session?.did;
-
-          if (!userDid) {
-            throw new Error('User session not available');
-          }
-
-          // List existing follows to check for duplicates
-          return await agent.com.atproto.repo.listRecords({
-            repo: userDid,
-            collection: 'app.bsky.graph.follow',
-            limit: 100, // Should be enough to find recent follows
-          });
-        },
-        'listFollows',
-        { targetDid }
-      );
-
-      // Check if any of the follows match the target user
-      for (const record of response.data.records) {
-        const followRecord = record.value as any;
-        if (followRecord.subject === targetDid) {
-          return {
-            uri: record.uri,
-            cid: record.cid,
-          };
-        }
-      }
-
-      return null;
-    } catch (error) {
-      this.logger.warn('Could not check for existing follow', error);
-      return null;
     }
   }
 }

--- a/src/tools/implementations/get-user-profile-tool.ts
+++ b/src/tools/implementations/get-user-profile-tool.ts
@@ -180,34 +180,45 @@ export class GetUserProfileTool extends BaseTool {
         this.validateActor(actor);
       }
 
-      // Get the user profiles from AT Protocol
-      const response = await this.executeAtpOperation(
-        async () => {
-          const agent = this.atpClient.getAgent();
-          return await agent.getProfiles({ actors });
-        },
-        'getProfiles',
-        { actorCount: actors.length }
-      );
+      // app.bsky.actor.getProfiles caps `actors` at 25 per request, so chunk
+      // larger requests into batches of 25 and concatenate the results.
+      const MAX_ACTORS_PER_REQUEST = 25;
+      const batches: string[][] = [];
+      for (let i = 0; i < actors.length; i += MAX_ACTORS_PER_REQUEST) {
+        batches.push(actors.slice(i, i + MAX_ACTORS_PER_REQUEST));
+      }
 
-      const profiles = response.data.profiles.map((profileData: any) => ({
-        did: profileData.did as DID,
-        handle: profileData.handle,
-        displayName: profileData.displayName,
-        description: profileData.description,
-        avatar: profileData.avatar,
-        banner: profileData.banner,
-        followersCount: profileData.followersCount,
-        followsCount: profileData.followsCount,
-        postsCount: profileData.postsCount,
-        indexedAt: profileData.indexedAt,
-        viewer: profileData.viewer
+      const profileData: any[] = [];
+      for (const batch of batches) {
+        const response = await this.executeAtpOperation(
+          async () => {
+            const agent = this.atpClient.getAgent();
+            return await agent.getProfiles({ actors: batch });
+          },
+          'getProfiles',
+          { actorCount: batch.length }
+        );
+        profileData.push(...response.data.profiles);
+      }
+
+      const profiles = profileData.map((p: any) => ({
+        did: p.did as DID,
+        handle: p.handle,
+        displayName: p.displayName,
+        description: p.description,
+        avatar: p.avatar,
+        banner: p.banner,
+        followersCount: p.followersCount,
+        followsCount: p.followsCount,
+        postsCount: p.postsCount,
+        indexedAt: p.indexedAt,
+        viewer: p.viewer
           ? {
-              muted: profileData.viewer.muted,
-              blockedBy: profileData.viewer.blockedBy,
-              blocking: profileData.viewer.blocking,
-              following: profileData.viewer.following,
-              followedBy: profileData.viewer.followedBy,
+              muted: p.viewer.muted,
+              blockedBy: p.viewer.blockedBy,
+              blocking: p.viewer.blocking,
+              following: p.viewer.following,
+              followedBy: p.viewer.followedBy,
             }
           : undefined,
       }));

--- a/src/tools/implementations/like-post-tool.ts
+++ b/src/tools/implementations/like-post-tool.ts
@@ -5,7 +5,7 @@
 import { z } from 'zod';
 import { BaseTool, ToolAuthMode } from './base-tool.js';
 import type { AtpClient } from '../../utils/atp-client.js';
-import type { ATURI, CID, ILikePostParams } from '../../types/index.js';
+import { type ATURI, type CID, type ILikePostParams, ValidationError } from '../../types/index.js';
 
 /**
  * Zod schema for like post parameters
@@ -181,27 +181,25 @@ export class UnlikePostTool extends BaseTool {
         likeUri: params.likeUri,
       });
 
-      // Validate the like URI
+      // Validate the like URI and pin the collection: the URI is untrusted, so we
+      // must NOT delete whatever record type it happens to name. Passing e.g. a
+      // post or follow URI here would otherwise delete that record.
       this.validateAtUri(params.likeUri);
+      const { collection } = this.parseAtUri(params.likeUri);
+      if (collection !== 'app.bsky.feed.like') {
+        throw new ValidationError(
+          `likeUri must reference a like record (collection "${collection}" is not app.bsky.feed.like)`,
+          'likeUri',
+          params.likeUri
+        );
+      }
 
-      // Delete the like record
+      // Delete the like record via the SDK helper, which pins the collection to
+      // app.bsky.feed.like and the repo to the authenticated user's own DID.
       await this.executeAtpOperation(
         async () => {
           const agent = this.atpClient.getAgent();
-          const uriParts = params.likeUri.replace('at://', '').split('/');
-          const did = uriParts[0];
-          const collection = uriParts[1];
-          const rkey = uriParts[2];
-
-          if (!did || !collection || !rkey) {
-            throw new Error(`Invalid AT URI format: ${params.likeUri}`);
-          }
-
-          return await agent.com.atproto.repo.deleteRecord({
-            repo: did,
-            collection,
-            rkey,
-          });
+          return await agent.deleteLike(params.likeUri);
         },
         'deleteLike',
         { likeUri: params.likeUri }

--- a/src/tools/implementations/media-tools.ts
+++ b/src/tools/implementations/media-tools.ts
@@ -19,6 +19,29 @@ function mediaBaseDir(): string {
   return process.env['ATPROTO_MEDIA_DIR'] ?? process.cwd();
 }
 
+/** MIME types accepted for remotely-fetched link-preview thumbnails. */
+const ALLOWED_IMAGE_MIME = new Set([
+  'image/jpeg',
+  'image/png',
+  'image/gif',
+  'image/webp',
+  'image/avif',
+]);
+
+/**
+ * Normalize and validate an image Content-Type for upload. The value comes from a
+ * remote server (the link-preview target), so it is untrusted: only known image
+ * types are accepted, and parameters (e.g. `; charset=...`) are stripped. Returns
+ * the normalized MIME, or null if it is missing or not an allowed image type.
+ */
+export function safeImageMime(contentType: string | null | undefined): string | null {
+  if (!contentType) {
+    return null;
+  }
+  const mime = contentType.split(';')[0]?.trim().toLowerCase() ?? '';
+  return ALLOWED_IMAGE_MIME.has(mime) ? mime : null;
+}
+
 const UploadImageSchema = z.object({
   filePath: z.string().min(1, 'File path is required'),
   altText: z.string().max(1000, 'Alt text cannot exceed 1000 characters').optional(),
@@ -594,34 +617,39 @@ export class GenerateLinkPreviewTool extends BaseTool {
             timeoutMs: 10_000,
           });
 
-          if (imageResponse.status >= 200 && imageResponse.status < 300) {
+          // Only upload the thumbnail when the remote response is actually a
+          // known image type — never store an arbitrary (e.g. text/html or
+          // octet-stream) payload as a blob just because the page advertised it
+          // as og:image. Also enforce the 1MB size cap.
+          const contentType = safeImageMime(imageResponse.contentType);
+          if (
+            imageResponse.status >= 200 &&
+            imageResponse.status < 300 &&
+            contentType &&
+            imageResponse.body.length <= 1024 * 1024
+          ) {
             const imageBuffer = imageResponse.body;
 
-            // Check image size (max 1MB)
-            if (imageBuffer.length <= 1024 * 1024) {
-              const contentType = imageResponse.contentType || 'image/jpeg';
+            const uploadResponse = await this.executeAtpOperation(
+              async () => {
+                const agent = this.atpClient.getAgent();
+                return await agent.uploadBlob(imageBuffer, {
+                  encoding: contentType,
+                });
+              },
+              'uploadThumbnail',
+              { imageUrl, size: imageBuffer.length }
+            );
 
-              const uploadResponse = await this.executeAtpOperation(
-                async () => {
-                  const agent = this.atpClient.getAgent();
-                  return await agent.uploadBlob(imageBuffer, {
-                    encoding: contentType,
-                  });
-                },
-                'uploadThumbnail',
-                { imageUrl, size: imageBuffer.length }
-              );
-
-              thumbBlob = {
-                blob: {
-                  type: 'blob',
-                  // Stringify the multiformats CID (see UploadImageTool).
-                  ref: uploadResponse.data?.blob?.ref?.toString() ?? '',
-                  mimeType: uploadResponse.data?.blob?.mimeType || contentType,
-                  size: uploadResponse.data?.blob?.size || imageBuffer.length,
-                },
-              };
-            }
+            thumbBlob = {
+              blob: {
+                type: 'blob',
+                // Stringify the multiformats CID (see UploadImageTool).
+                ref: uploadResponse.data?.blob?.ref?.toString() ?? '',
+                mimeType: uploadResponse.data?.blob?.mimeType || contentType,
+                size: uploadResponse.data?.blob?.size || imageBuffer.length,
+              },
+            };
           }
         } catch (imageError) {
           this.logger.warn('Failed to download thumbnail image', imageError as Error);

--- a/src/tools/implementations/moderation-tools.ts
+++ b/src/tools/implementations/moderation-tools.ts
@@ -3,8 +3,17 @@
  */
 
 import { z } from 'zod';
-import { BaseTool } from './base-tool.js';
+import { BaseTool, ToolAuthMode } from './base-tool.js';
 import type { AtpClient } from '../../utils/atp-client.js';
+
+/**
+ * Map a short report-reason key (e.g. 'spam') to its AT Protocol moderation
+ * reason NSID (e.g. com.atproto.moderation.defs#reasonSpam). Shared by the
+ * content and user report tools.
+ */
+function toReasonNsid(reasonType: string): string {
+  return `com.atproto.moderation.defs#reason${reasonType.charAt(0).toUpperCase()}${reasonType.slice(1)}`;
+}
 
 const MuteUserSchema = z.object({
   actor: z.string().min(1, 'Actor (DID or handle) is required'),
@@ -325,7 +334,7 @@ export class ReportContentTool extends BaseTool {
         async () => {
           const agent = this.atpClient.getAgent();
           return await agent.com.atproto.moderation.createReport({
-            reasonType: `com.atproto.moderation.defs#reason${params.reasonType.charAt(0).toUpperCase() + params.reasonType.slice(1)}`,
+            reasonType: toReasonNsid(params.reasonType),
             reason: params.reason,
             subject: {
               $type: 'com.atproto.repo.strongRef',
@@ -399,7 +408,7 @@ export class ReportUserTool extends BaseTool {
         async () => {
           const agent = this.atpClient.getAgent();
           return await agent.com.atproto.moderation.createReport({
-            reasonType: `com.atproto.moderation.defs#reason${params.reasonType.charAt(0).toUpperCase() + params.reasonType.slice(1)}`,
+            reasonType: toReasonNsid(params.reasonType),
             reason: params.reason,
             subject: {
               $type: 'com.atproto.admin.defs#repoRef',
@@ -466,7 +475,9 @@ export class AnalyzeModerationStatusTool extends BaseTool {
   };
 
   constructor(atpClient: AtpClient) {
-    super(atpClient, 'AnalyzeModerationStatus');
+    // Public content labels are readable without auth; personal moderation state
+    // (blocks/mutes) is added when authenticated. Hence ENHANCED, not PRIVATE.
+    super(atpClient, 'AnalyzeModerationStatus', ToolAuthMode.ENHANCED);
   }
 
   protected async execute(params: { subject: string; includeLabels?: boolean }): Promise<{

--- a/src/tools/implementations/moderation-tools.ts
+++ b/src/tools/implementations/moderation-tools.ts
@@ -483,9 +483,12 @@ export class AnalyzeModerationStatusTool extends BaseTool {
       blocked?: boolean;
       muted?: boolean;
       blockedBy?: boolean;
-      blocking?: boolean;
-      mutedByList?: boolean;
-      blockedByList?: boolean;
+      // `blocking` is the AT-URI of your block record (a string), not a boolean.
+      blocking?: string;
+      // mutedByList/blockingByList are list-view objects from ViewerState, not
+      // booleans. AT Protocol's ViewerState has no `blockedByList` field.
+      mutedByList?: { uri: string; name?: string };
+      blockingByList?: { uri: string; name?: string };
     };
     analysis: {
       hasContentWarnings: boolean;

--- a/src/tools/implementations/reply-to-post-tool.ts
+++ b/src/tools/implementations/reply-to-post-tool.ts
@@ -72,8 +72,8 @@ export class ReplyToPostTool extends BaseTool {
 
       // Get CIDs for the root and parent posts
       const [rootCid, parentCid] = await Promise.all([
-        this.getCidFromUri(params.root),
-        this.getCidFromUri(params.parent),
+        this.getReplyCid(params.root),
+        this.getReplyCid(params.parent),
       ]);
 
       // Detect richtext facets so mentions/links/hashtags are not inert text.
@@ -143,51 +143,17 @@ export class ReplyToPostTool extends BaseTool {
   }
 
   /**
-   * Get CID from AT Protocol URI by fetching the record
+   * Resolve a post's CID via the shared BaseTool.getCidFromUri, adding the
+   * reply-specific guidance on failure.
+   *
+   * A reply must reference the parent/root post by its real CID — falling back
+   * to the rkey (or a literal placeholder) produces a structurally invalid
+   * reply record, so we fail clearly instead.
    */
-  private async getCidFromUri(uri: string): Promise<string> {
+  private async getReplyCid(uri: string): Promise<string> {
     try {
-      this.logger.debug('Resolving CID from URI', { uri });
-
-      const response = await this.executeAtpOperation(
-        async () => {
-          const agent = this.atpClient.getAgent();
-          // Parse the AT URI to extract components
-          const uriParts = uri.replace('at://', '').split('/');
-          if (uriParts.length < 3) {
-            throw new Error(`Invalid AT URI format: ${uri}`);
-          }
-
-          const did = uriParts[0];
-          const collection = uriParts[1];
-          const rkey = uriParts[2];
-
-          if (!did || !collection || !rkey) {
-            throw new Error(`Invalid AT URI components: ${uri}`);
-          }
-
-          // Get the record to obtain its CID
-          return await agent.com.atproto.repo.getRecord({
-            repo: did,
-            collection,
-            rkey,
-          });
-        },
-        'getRecord',
-        { uri }
-      );
-
-      const cid = response.data.cid;
-      if (!cid) {
-        throw new Error(`No CID found for URI: ${uri}`);
-      }
-      this.logger.debug('Resolved CID from URI', { uri, cid });
-      return cid;
+      return await this.getCidFromUri(uri);
     } catch (error) {
-      this.logger.error('Failed to resolve CID from URI', error);
-      // A reply must reference the parent/root post by its real CID. Previously
-      // this fell back to the rkey (or the literal 'fallback-cid'), producing a
-      // structurally invalid reply record. Fail clearly instead.
       throw new Error(
         `Could not resolve the CID for ${uri}: ${
           error instanceof Error ? error.message : 'Unknown error'

--- a/src/tools/implementations/repost-tool.ts
+++ b/src/tools/implementations/repost-tool.ts
@@ -5,7 +5,7 @@
 import { z } from 'zod';
 import { BaseTool, ToolAuthMode } from './base-tool.js';
 import type { AtpClient } from '../../utils/atp-client.js';
-import type { ATURI, CID, IRepostParams } from '../../types/index.js';
+import { type ATURI, type CID, type IRepostParams, ValidationError } from '../../types/index.js';
 
 /**
  * Zod schema for repost parameters
@@ -138,9 +138,15 @@ export class RepostTool extends BaseTool {
    * Create a quote post (post with embedded repost)
    */
   private async createQuotePost(params: IRepostParams): Promise<unknown> {
+    // Detect richtext facets (mentions/links/hashtags) just like a normal post —
+    // agent.post() does NOT auto-detect them, so without this the quote text's
+    // links/@mentions/#hashtags would be stored as inert plain text.
+    const { text, facets } = await this.buildRichText(params.text ?? '');
+
     const quotePostRecord = {
       $type: 'app.bsky.feed.post' as const,
-      text: params.text ?? '',
+      text,
+      ...(facets ? { facets } : {}),
       embed: {
         $type: 'app.bsky.embed.record',
         record: {
@@ -198,27 +204,24 @@ export class UnrepostTool extends BaseTool {
         repostUri: params.repostUri,
       });
 
-      // Validate the repost URI
+      // Validate the repost URI and pin the collection: the URI is untrusted, so
+      // we must NOT delete whatever record type it happens to name.
       this.validateAtUri(params.repostUri);
+      const { collection } = this.parseAtUri(params.repostUri);
+      if (collection !== 'app.bsky.feed.repost') {
+        throw new ValidationError(
+          `repostUri must reference a repost record (collection "${collection}" is not app.bsky.feed.repost)`,
+          'repostUri',
+          params.repostUri
+        );
+      }
 
-      // Delete the repost record
+      // Delete the repost record via the SDK helper, which pins the collection to
+      // app.bsky.feed.repost and the repo to the authenticated user's own DID.
       await this.executeAtpOperation(
         async () => {
           const agent = this.atpClient.getAgent();
-          const uriParts = params.repostUri.replace('at://', '').split('/');
-          const did = uriParts[0];
-          const collection = uriParts[1];
-          const rkey = uriParts[2];
-
-          if (!did || !collection || !rkey) {
-            throw new Error(`Invalid AT URI format: ${params.repostUri}`);
-          }
-
-          return await agent.com.atproto.repo.deleteRecord({
-            repo: did,
-            collection,
-            rkey,
-          });
+          return await agent.deleteRepost(params.repostUri);
         },
         'deleteRepost',
         { repostUri: params.repostUri }

--- a/src/tools/implementations/search-posts-tool.ts
+++ b/src/tools/implementations/search-posts-tool.ts
@@ -114,8 +114,10 @@ export class SearchPostsTool extends BaseTool {
         }
       );
 
-      // Transform posts to our interface
-      const posts: IAtpPost[] = response.data.posts.map((post: any) => this.transformPost(post));
+      // Transform posts to our interface (shared mapper lives on BaseTool)
+      const posts: IAtpPost[] = response.data.posts.map((post: any) =>
+        this.transformPostView(post)
+      );
 
       const hasMore = !!response.data.cursor;
       const cursor = response.data.cursor;
@@ -139,56 +141,6 @@ export class SearchPostsTool extends BaseTool {
       this.logger.error('Failed to search posts', error);
       this.formatError(error);
     }
-  }
-
-  /**
-   * Transform AT Protocol post data to our interface
-   */
-  private transformPost(postData: any): IAtpPost {
-    return {
-      uri: postData.uri,
-      cid: postData.cid,
-      author: {
-        did: postData.author.did,
-        handle: postData.author.handle,
-        displayName: postData.author.displayName,
-        description: postData.author.description,
-        avatar: postData.author.avatar,
-        followersCount: postData.author.followersCount,
-        followsCount: postData.author.followsCount,
-        postsCount: postData.author.postsCount,
-      },
-      record: {
-        text: postData.record.text || '',
-        createdAt: postData.record.createdAt,
-        reply: postData.record.reply
-          ? {
-              root: {
-                uri: postData.record.reply.root.uri,
-                cid: postData.record.reply.root.cid,
-              },
-              parent: {
-                uri: postData.record.reply.parent.uri,
-                cid: postData.record.reply.parent.cid,
-              },
-            }
-          : undefined,
-        embed: postData.record.embed,
-        langs: postData.record.langs,
-        labels: postData.record.labels,
-        tags: postData.record.tags,
-      },
-      replyCount: postData.replyCount,
-      repostCount: postData.repostCount,
-      likeCount: postData.likeCount,
-      indexedAt: postData.indexedAt,
-      viewer: postData.viewer
-        ? {
-            repost: postData.viewer.repost,
-            like: postData.viewer.like,
-          }
-        : undefined,
-    };
   }
 
   /**

--- a/src/tools/implementations/social-graph-tools.ts
+++ b/src/tools/implementations/social-graph-tools.ts
@@ -90,7 +90,10 @@ export class GetFollowersTool extends BaseTool {
         }
       );
 
-      // Transform followers to our interface
+      // Transform followers to our interface. Note: getFollowers returns
+      // ProfileView entries, which do NOT carry followersCount/followsCount/
+      // postsCount (only ProfileViewDetailed does), so we omit those rather than
+      // emit always-undefined fields that imply the data is available.
       const followers = response.data.followers.map((follower: any) => ({
         did: follower.did as DID,
         handle: follower.handle,
@@ -98,9 +101,6 @@ export class GetFollowersTool extends BaseTool {
         description: follower.description,
         avatar: follower.avatar,
         banner: follower.banner,
-        followersCount: follower.followersCount,
-        followsCount: follower.followsCount,
-        postsCount: follower.postsCount,
         indexedAt: follower.indexedAt,
       }));
 
@@ -177,7 +177,9 @@ export class GetFollowsTool extends BaseTool {
         }
       );
 
-      // Transform follows to our interface
+      // Transform follows to our interface. getFollows returns ProfileView
+      // entries without follower/follow/post counts (see GetFollowersTool), so
+      // those fields are omitted rather than emitted as always-undefined.
       const follows = response.data.follows.map((follow: any) => ({
         did: follow.did as DID,
         handle: follow.handle,
@@ -185,9 +187,6 @@ export class GetFollowsTool extends BaseTool {
         description: follow.description,
         avatar: follow.avatar,
         banner: follow.banner,
-        followersCount: follow.followersCount,
-        followsCount: follow.followsCount,
-        postsCount: follow.postsCount,
         indexedAt: follow.indexedAt,
       }));
 

--- a/src/tools/implementations/timeline-tools.ts
+++ b/src/tools/implementations/timeline-tools.ts
@@ -68,7 +68,7 @@ export class GetTimelineTool extends BaseTool {
 
       // Transform posts to our interface
       const posts: IAtpPost[] = response.data.feed.map((feedItem: any) =>
-        this.transformPost(feedItem.post)
+        this.transformPostView(feedItem.post)
       );
 
       const hasMore = !!response.data.cursor;
@@ -91,56 +91,6 @@ export class GetTimelineTool extends BaseTool {
       this.logger.error('Failed to retrieve timeline', error);
       this.formatError(error);
     }
-  }
-
-  /**
-   * Transform AT Protocol post data to our interface
-   */
-  private transformPost(postData: any): IAtpPost {
-    return {
-      uri: postData.uri,
-      cid: postData.cid,
-      author: {
-        did: postData.author.did,
-        handle: postData.author.handle,
-        displayName: postData.author.displayName,
-        description: postData.author.description,
-        avatar: postData.author.avatar,
-        followersCount: postData.author.followersCount,
-        followsCount: postData.author.followsCount,
-        postsCount: postData.author.postsCount,
-      },
-      record: {
-        text: postData.record.text || '',
-        createdAt: postData.record.createdAt,
-        reply: postData.record.reply
-          ? {
-              root: {
-                uri: postData.record.reply.root.uri,
-                cid: postData.record.reply.root.cid,
-              },
-              parent: {
-                uri: postData.record.reply.parent.uri,
-                cid: postData.record.reply.parent.cid,
-              },
-            }
-          : undefined,
-        embed: postData.record.embed,
-        langs: postData.record.langs,
-        labels: postData.record.labels,
-        tags: postData.record.tags,
-      },
-      replyCount: postData.replyCount,
-      repostCount: postData.repostCount,
-      likeCount: postData.likeCount,
-      indexedAt: postData.indexedAt,
-      viewer: postData.viewer
-        ? {
-            repost: postData.viewer.repost,
-            like: postData.viewer.like,
-          }
-        : undefined,
-    };
   }
 
   /**
@@ -188,7 +138,7 @@ export class GetTimelineTool extends BaseTool {
       );
 
       const posts: IAtpPost[] = response.data.feed.map((feedItem: any) =>
-        this.transformPost(feedItem.post)
+        this.transformPostView(feedItem.post)
       );
 
       return {
@@ -246,7 +196,7 @@ export class GetTimelineTool extends BaseTool {
       );
 
       const posts: IAtpPost[] = response.data.feed.map((feedItem: any) =>
-        this.transformPost(feedItem.post)
+        this.transformPostView(feedItem.post)
       );
 
       return {

--- a/src/utils/__tests__/atp-client.test.ts
+++ b/src/utils/__tests__/atp-client.test.ts
@@ -4,7 +4,7 @@
 
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { AtpClient } from '../atp-client.js';
-import { AuthenticationError, AtpError } from '../../types/index.js';
+import { AuthenticationError, AtpError, ValidationError } from '../../types/index.js';
 import {
   mockConsole,
   expectToThrow,
@@ -127,15 +127,16 @@ describe('AtpClient', () => {
       );
     });
 
-    it('should handle session refresh', async () => {
+    it('refreshes the session on expiry without a spurious re-login', async () => {
       const mockSession = createMockSession();
       mockAgent.login.mockResolvedValue({
         success: true,
         data: mockSession,
       });
-      mockAgent.refreshSession.mockResolvedValue({
-        success: true,
-      });
+      // The real @atproto/api AtpAgent.refreshSession() returns Promise<void>.
+      // The client must NOT inspect a (non-existent) `.success` field on the
+      // result — doing so throws a TypeError that forces a needless full re-login.
+      mockAgent.refreshSession.mockResolvedValue(undefined);
 
       await client.initialize();
 
@@ -153,6 +154,9 @@ describe('AtpClient', () => {
       await new Promise(resolve => setTimeout(resolve, 10));
 
       expect(mockAgent.refreshSession).toHaveBeenCalled();
+      // login was called exactly once (initial auth) — the void refresh result
+      // must not be misread as a failure that triggers re-authentication.
+      expect(mockAgent.login).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -226,6 +230,42 @@ describe('AtpClient', () => {
       expect(result.success).toBe(false);
       if (!result.success) {
         expect(result.error.code).toBe('RATE_LIMIT_EXCEEDED');
+      }
+    });
+
+    it('maps 404 to a not-found AtpError, not a ValidationError', async () => {
+      const error = { status: 404, message: 'Could not find record' };
+      const result = await client.executeRequest(vi.fn().mockRejectedValue(error));
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        // A 404 must not be reported to the LLM as "invalid parameters".
+        expect(result.error).toBeInstanceOf(AtpError);
+        expect(result.error).not.toBeInstanceOf(ValidationError);
+        expect(result.error.code).toBe('NOT_FOUND');
+        expect(result.error.statusCode).toBe(404);
+      }
+    });
+
+    it('maps 403 to a forbidden AtpError, not a ValidationError', async () => {
+      const error = { status: 403, message: 'Blocked by author' };
+      const result = await client.executeRequest(vi.fn().mockRejectedValue(error));
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).not.toBeInstanceOf(ValidationError);
+        expect(result.error.code).toBe('FORBIDDEN');
+        expect(result.error.statusCode).toBe(403);
+      }
+    });
+
+    it('still maps 400 to a ValidationError', async () => {
+      const error = { status: 400, message: 'Invalid request body' };
+      const result = await client.executeRequest(vi.fn().mockRejectedValue(error));
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toBeInstanceOf(ValidationError);
       }
     });
   });

--- a/src/utils/__tests__/atp-client.test.ts
+++ b/src/utils/__tests__/atp-client.test.ts
@@ -244,4 +244,20 @@ describe('AtpClient', () => {
       expect(agent).toBe(mockAgent);
     });
   });
+
+  describe('executeAuthenticatedRequest without credentials', () => {
+    it('denies the operation without invoking it when no credentials are configured', async () => {
+      // No authMethod/credentials -> the auth gate must fail closed.
+      const noCredClient = new AtpClient({ service: 'https://bsky.social' } as any);
+      const operation = vi.fn().mockResolvedValue('should not run');
+
+      const result = await noCredClient.executeAuthenticatedRequest(operation);
+
+      expect(result.success).toBe(false);
+      expect(operation).not.toHaveBeenCalled();
+      if (!result.success) {
+        expect(result.error).toBeInstanceOf(AuthenticationError);
+      }
+    });
+  });
 });

--- a/src/utils/__tests__/config-redaction.test.ts
+++ b/src/utils/__tests__/config-redaction.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Regression test: configuration logging must not emit credentials in plaintext.
+ * Passwords/secrets are fully redacted; the identifier and clientId are masked
+ * (they are sensitive enough not to belong in logs verbatim).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { redactConfigForLog } from '../config.js';
+import type { IMcpServerConfig } from '../../types/index.js';
+
+const baseConfig: IMcpServerConfig = {
+  port: 3000,
+  host: 'localhost',
+  name: 'atproto-mcp',
+  version: '0.0.0',
+  description: 'test',
+  atproto: {
+    service: 'https://bsky.social',
+    identifier: 'test.bsky.social',
+    password: 'super-secret-pw',
+    clientId: 'client-123456',
+    clientSecret: 'client-secret-value',
+    authMethod: 'app-password',
+  },
+};
+
+describe('redactConfigForLog', () => {
+  it('fully redacts password and clientSecret', () => {
+    const masked = redactConfigForLog(baseConfig);
+    expect(masked.atproto.password).toBe('[REDACTED]');
+    expect(masked.atproto.clientSecret).toBe('[REDACTED]');
+  });
+
+  it('masks identifier and clientId rather than logging them verbatim', () => {
+    const masked = redactConfigForLog(baseConfig);
+    expect(masked.atproto.identifier).not.toBe('test.bsky.social');
+    expect(masked.atproto.identifier).toMatch(/\*\*\*/);
+    expect(masked.atproto.clientId).not.toBe('client-123456');
+    expect(masked.atproto.clientId).toMatch(/\*\*\*/);
+  });
+
+  it('leaves non-sensitive fields intact', () => {
+    const masked = redactConfigForLog(baseConfig);
+    expect(masked.atproto.service).toBe('https://bsky.social');
+    expect(masked.name).toBe('atproto-mcp');
+  });
+});

--- a/src/utils/__tests__/firehose-client.test.ts
+++ b/src/utils/__tests__/firehose-client.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Lifecycle tests for FirehoseClient against a real local WebSocket server.
+ *
+ * These exercise the socket/reconnect/subscription lifecycle (not frame
+ * decoding, which is intentionally not implemented). They guard against socket
+ * leaks on reconnect and stale subscriptions surviving a disconnect.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { WebSocketServer, type WebSocket as WsSocket } from 'ws';
+import type { AddressInfo } from 'net';
+import { FirehoseClient } from '../firehose-client.js';
+import type { IAtpConfig } from '../../types/index.js';
+
+const baseConfig: IAtpConfig = {
+  service: 'https://bsky.social',
+  authMethod: 'app-password',
+} as IAtpConfig;
+
+function waitFor(predicate: () => boolean, timeoutMs = 5000): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const start = Date.now();
+    const tick = () => {
+      if (predicate()) return resolve();
+      if (Date.now() - start > timeoutMs) return reject(new Error('waitFor timed out'));
+      setTimeout(tick, 20);
+    };
+    tick();
+  });
+}
+
+describe('FirehoseClient lifecycle', () => {
+  let server: WebSocketServer;
+  let port: number;
+  let connections: WsSocket[] = [];
+  let client: FirehoseClient | null = null;
+  const prevRelay = process.env['ATPROTO_RELAY'];
+
+  beforeEach(async () => {
+    connections = [];
+    await new Promise<void>(resolve => {
+      server = new WebSocketServer({ port: 0 }, resolve);
+    });
+    port = (server.address() as AddressInfo).port;
+    process.env['ATPROTO_RELAY'] = `ws://127.0.0.1:${port}`;
+    server.on('connection', socket => connections.push(socket));
+  });
+
+  afterEach(async () => {
+    if (client) await client.disconnect();
+    client = null;
+    for (const c of connections) c.terminate();
+    await new Promise<void>(resolve => server.close(() => resolve()));
+    if (prevRelay === undefined) delete process.env['ATPROTO_RELAY'];
+    else process.env['ATPROTO_RELAY'] = prevRelay;
+  });
+
+  it('connects to a ws:// relay and reports connected', async () => {
+    client = new FirehoseClient(baseConfig);
+    await client.connect();
+    await waitFor(() => client!.isConnected());
+    expect(client.isConnected()).toBe(true);
+    expect(connections.length).toBe(1);
+  });
+
+  it('clears subscriptions on disconnect', async () => {
+    client = new FirehoseClient(baseConfig);
+    client.subscribe({ id: 'sub1', onEvent: () => {} });
+    client.subscribe({ id: 'sub2', onEvent: () => {} });
+    expect(client.getSubscriptionCount()).toBe(2);
+
+    await client.connect();
+    await waitFor(() => client!.isConnected());
+    await client.disconnect();
+
+    expect(client.isConnected()).toBe(false);
+    expect(client.getSubscriptionCount()).toBe(0);
+  });
+
+  it('reconnects automatically after the server drops the connection', async () => {
+    client = new FirehoseClient(baseConfig);
+    await client.connect();
+    await waitFor(() => connections.length === 1);
+
+    // Server-initiated drop should trigger an automatic reconnect.
+    connections[0]!.close();
+
+    await waitFor(() => connections.length >= 2, 8000);
+    expect(connections.length).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/src/utils/__tests__/firehose-subscriptions.test.ts
+++ b/src/utils/__tests__/firehose-subscriptions.test.ts
@@ -1,0 +1,42 @@
+/**
+ * Regression test: processEvent must iterate a snapshot of the subscriptions, so
+ * a handler that unsubscribes (or subscribes) another listener during dispatch
+ * does not cause the live Map iteration to skip a still-valid subscriber.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { FirehoseClient, type IFirehoseEvent } from '../firehose-client.js';
+
+const event: IFirehoseEvent = {
+  type: 'commit',
+  seq: 1,
+  time: new Date(0).toISOString(),
+  repo: 'did:plc:repo',
+  commit: { rev: 'r', operation: 'create', collection: 'app.bsky.feed.post', rkey: 'x' },
+};
+
+describe('FirehoseClient.processEvent subscription iteration', () => {
+  it('still delivers to a subscriber that another handler unsubscribes mid-dispatch', () => {
+    const client = new FirehoseClient({ service: 'https://bsky.social' } as never);
+
+    const bHandler = vi.fn();
+
+    // A's handler unsubscribes B during dispatch (mutating the Map mid-iteration).
+    client.subscribe({
+      id: 'A',
+      onEvent: () => client.unsubscribe('B'),
+    });
+    client.subscribe({
+      id: 'B',
+      onEvent: bHandler,
+    });
+
+    // Invoke the private dispatcher directly (decoding is not wired up, so it is
+    // never reached via the socket in this build).
+    (client as unknown as { processEvent(e: IFirehoseEvent): void }).processEvent(event);
+
+    // With live Map iteration, B is skipped because A deleted it before it was
+    // reached. A snapshot delivers the in-flight event to B regardless.
+    expect(bHandler).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/utils/__tests__/security.test.ts
+++ b/src/utils/__tests__/security.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import { Logger, LogLevel } from '../logger.js';
-import { type ISecurityConfig, SecurityManager } from '../security.js';
+import { RateLimiter, type ISecurityConfig, SecurityManager } from '../security.js';
 
 const logger = new Logger('SecurityTest', LogLevel.ERROR);
 
@@ -50,5 +50,52 @@ describe('SecurityManager.checkRateLimit', () => {
     for (let i = 0; i < 250; i++) {
       expect(sm.checkRateLimit('tool:create_post')).toBe(true);
     }
+  });
+});
+
+describe('RateLimiter', () => {
+  const limiters: RateLimiter[] = [];
+  afterEach(() => {
+    for (const l of limiters.splice(0)) l.destroy();
+  });
+
+  it('caps the number of tracked identifiers to bound memory under a key flood', () => {
+    const limiter = new RateLimiter(
+      { windowMs: 60000, maxRequests: 5, maxTrackedIdentifiers: 10 },
+      logger
+    );
+    limiters.push(limiter);
+
+    // Flood with 1000 distinct identifiers (e.g. attacker-controlled keys).
+    for (let i = 0; i < 1000; i++) {
+      limiter.isAllowed(`flood-${i}`);
+    }
+
+    // The map must not grow unbounded — it stays at/below the configured cap.
+    expect(limiter.getMetrics().trackedIdentifiers).toBeLessThanOrEqual(10);
+  });
+
+  it('still enforces the limit for an active identifier under a key flood', () => {
+    const limiter = new RateLimiter(
+      { windowMs: 60000, maxRequests: 3, maxTrackedIdentifiers: 100 },
+      logger
+    );
+    limiters.push(limiter);
+
+    // Touch the active key repeatedly so it stays "recent" (LRU keeps it).
+    for (let i = 0; i < 3; i++) expect(limiter.isAllowed('active')).toBe(true);
+    expect(limiter.isAllowed('active')).toBe(false);
+  });
+
+  it('computes getResetTime without spreading the timestamp array', () => {
+    const limiter = new RateLimiter({ windowMs: 60000, maxRequests: 100 }, logger);
+    limiters.push(limiter);
+
+    const before = Date.now();
+    limiter.isAllowed('id');
+    const reset = limiter.getResetTime('id');
+    // Reset = oldest request + window, i.e. roughly one window from now.
+    expect(reset).toBeGreaterThanOrEqual(before + 60000 - 1000);
+    expect(reset).toBeLessThanOrEqual(Date.now() + 60000 + 1000);
   });
 });

--- a/src/utils/__tests__/security.test.ts
+++ b/src/utils/__tests__/security.test.ts
@@ -1,6 +1,12 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import { Logger, LogLevel } from '../logger.js';
-import { RateLimiter, type ISecurityConfig, SecurityManager } from '../security.js';
+import {
+  ErrorSanitizer,
+  InputSanitizer,
+  RateLimiter,
+  type ISecurityConfig,
+  SecurityManager,
+} from '../security.js';
 
 const logger = new Logger('SecurityTest', LogLevel.ERROR);
 
@@ -97,5 +103,61 @@ describe('RateLimiter', () => {
     // Reset = oldest request + window, i.e. roughly one window from now.
     expect(reset).toBeGreaterThanOrEqual(before + 60000 - 1000);
     expect(reset).toBeLessThanOrEqual(Date.now() + 60000 + 1000);
+  });
+});
+
+describe('ErrorSanitizer', () => {
+  it('genericizes messages containing sensitive terms in production', () => {
+    const sanitizer = new ErrorSanitizer(logger, false);
+    const result = sanitizer.sanitizeError(new Error('invalid password for user'));
+    expect(result.message).toBe('An internal error occurred');
+  });
+
+  it('passes through and truncates non-sensitive messages in production', () => {
+    const sanitizer = new ErrorSanitizer(logger, false);
+    const long = 'x'.repeat(500);
+    const result = sanitizer.sanitizeError(new Error(long));
+    expect(result.message.length).toBe(200);
+  });
+
+  it('returns detailed messages in development mode', () => {
+    const sanitizer = new ErrorSanitizer(logger, true);
+    const result = sanitizer.sanitizeError(new Error('database connection at /var/secret failed'));
+    expect(result.message).toBe('database connection at /var/secret failed');
+  });
+});
+
+describe('InputSanitizer', () => {
+  const sanitizer = new InputSanitizer(10000, logger);
+
+  it('strips angle brackets and javascript: protocol', () => {
+    const out = sanitizer.sanitizeString('<script>javascript:alert(1)</script>');
+    expect(out).not.toContain('<');
+    expect(out).not.toContain('>');
+    expect(out).not.toMatch(/javascript:/i);
+  });
+
+  it('rejects input longer than the configured maximum', () => {
+    const small = new InputSanitizer(5, logger);
+    expect(() => small.sanitizeString('abcdef')).toThrow(/maximum/);
+  });
+
+  it('does not pollute the prototype when sanitizing a __proto__ key', () => {
+    // Realistic attack vector: an own __proto__ key from parsed JSON.
+    const malicious = JSON.parse('{"__proto__": {"polluted": true}, "safe": "ok"}');
+    const result = sanitizer.sanitizeObject(malicious);
+
+    // Object.prototype must be untouched, and the result must not inherit the
+    // attacker-controlled prototype.
+    expect(({} as Record<string, unknown>)['polluted']).toBeUndefined();
+    expect(Object.getPrototypeOf(result)).toBe(Object.prototype);
+    expect((result as Record<string, unknown>)['polluted']).toBeUndefined();
+    expect((result as Record<string, unknown>)['safe']).toBe('ok');
+  });
+
+  it('validates AT Protocol DIDs and handles', () => {
+    expect(sanitizer.validateAtProtoIdentifier('did:plc:abc123')).toBe(true);
+    expect(sanitizer.validateAtProtoIdentifier('alice.bsky.social')).toBe(true);
+    expect(sanitizer.validateAtProtoIdentifier('not a handle')).toBe(false);
   });
 });

--- a/src/utils/__tests__/url-safety.test.ts
+++ b/src/utils/__tests__/url-safety.test.ts
@@ -1,4 +1,7 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { assertSafePath, isBlockedAddress, parseSafeHttpUrl, safeFetch } from '../url-safety.js';
 
 describe('isBlockedAddress', () => {
@@ -36,6 +39,9 @@ describe('isBlockedAddress', () => {
       '::a00:1', // IPv4-compatible 10.0.0.1
       '2002:7f00:1::1', // 6to4 wrapping 127.0.0.1
       '2002:a00:1::1', // 6to4 wrapping 10.0.0.1
+      '64:ff9b::7f00:1', // NAT64 wrapping 127.0.0.1
+      '64:ff9b::a00:1', // NAT64 wrapping 10.0.0.1
+      '64:ff9b::169.254.169.254', // NAT64 wrapping cloud metadata
     ]) {
       expect(isBlockedAddress(ip), `${ip} should be blocked`).toBe(true);
     }
@@ -90,6 +96,35 @@ describe('assertSafePath', () => {
       /outside|allowed/i
     );
     expect(() => assertSafePath('/etc/passwd', '/srv/media')).toThrow(/outside|allowed/i);
+  });
+
+  describe('symlink escapes', () => {
+    let root: string;
+
+    afterEach(() => {
+      if (root) rmSync(root, { recursive: true, force: true });
+    });
+
+    it('rejects a symlink inside the base dir that points outside it', () => {
+      root = mkdtempSync(join(tmpdir(), 'urlsafe-'));
+      const base = join(root, 'media');
+      mkdirSync(base);
+      // A secret outside the allowed directory, and a symlink inside it pointing there.
+      const secret = join(root, 'secret.txt');
+      writeFileSync(secret, 'top secret');
+      symlinkSync(secret, join(base, 'escape.txt'));
+
+      expect(() => assertSafePath('escape.txt', base)).toThrow(/outside|allowed|symlink/i);
+    });
+
+    it('still allows a real file inside the base dir', () => {
+      root = mkdtempSync(join(tmpdir(), 'urlsafe-'));
+      const base = join(root, 'media');
+      mkdirSync(base);
+      writeFileSync(join(base, 'photo.jpg'), 'data');
+
+      expect(() => assertSafePath('photo.jpg', base)).not.toThrow();
+    });
   });
 });
 

--- a/src/utils/__tests__/url-safety.test.ts
+++ b/src/utils/__tests__/url-safety.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { assertSafePath, isBlockedAddress, parseSafeHttpUrl } from '../url-safety.js';
+import { assertSafePath, isBlockedAddress, parseSafeHttpUrl, safeFetch } from '../url-safety.js';
 
 describe('isBlockedAddress', () => {
   it('blocks IPv4 loopback, private, link-local, and reserved ranges', () => {
@@ -90,5 +90,26 @@ describe('assertSafePath', () => {
       /outside|allowed/i
     );
     expect(() => assertSafePath('/etc/passwd', '/srv/media')).toThrow(/outside|allowed/i);
+  });
+});
+
+describe('safeFetch SSRF rejection', () => {
+  it('refuses to fetch loopback, private, link-local, and metadata targets', async () => {
+    for (const url of [
+      'http://127.0.0.1/',
+      'http://10.0.0.1/',
+      'http://169.254.169.254/latest/meta-data/', // cloud metadata endpoint
+      'http://[::1]/',
+      'http://0177.0.0.1/', // octal-obfuscated loopback
+      'http://2130706433/', // decimal-obfuscated loopback
+    ]) {
+      await expect(safeFetch(url), `should reject ${url}`).rejects.toThrow();
+    }
+  });
+
+  it('refuses non-http(s) schemes', async () => {
+    for (const url of ['file:///etc/passwd', 'ftp://example.com/x', 'gopher://example.com/']) {
+      await expect(safeFetch(url), `should reject ${url}`).rejects.toThrow();
+    }
   });
 });

--- a/src/utils/atp-client.ts
+++ b/src/utils/atp-client.ts
@@ -309,17 +309,12 @@ export class AtpClient {
     try {
       this.logger.debug('Refreshing session');
 
-      // Note: refreshSession method may not exist in current @atproto/api version
-      // This is a placeholder for when the method becomes available
       if ('refreshSession' in this.agent && typeof this.agent.refreshSession === 'function') {
-        const response = await (this.agent as any).refreshSession();
-
-        if (!response.success) {
-          throw new AuthenticationError('Session refresh failed', response, {
-            sessionActive: this.session?.active,
-          });
-        }
-
+        // AtpAgent.refreshSession() returns Promise<void> and throws on failure;
+        // it does NOT resolve to a { success } envelope. Awaiting it is the whole
+        // contract — inspecting a `.success` field would throw a TypeError and
+        // force a needless full re-login on every token refresh.
+        await this.agent.refreshSession();
         this.logger.info('Session refreshed successfully');
       } else {
         // Fallback: re-authenticate if refresh is not available
@@ -488,10 +483,30 @@ export class AtpClient {
         );
       }
 
-      if (errorObj.status >= 400 && errorObj.status < 500) {
+      // Only a genuine bad-request (400/422) is a client *parameter* problem.
+      // Other 4xx (403 forbidden, 404 not found, 409 conflict, ...) must NOT be
+      // reported to the caller as "invalid parameters" — that misleads the LLM
+      // into "fixing" arguments that were correct. Preserve the status and a
+      // meaningful code instead.
+      if (errorObj.status === 400 || errorObj.status === 422) {
         return new ValidationError(
-          errorObj.message || 'Client error',
+          errorObj.message || 'Invalid request',
           undefined,
+          errorObj,
+          context
+        );
+      }
+
+      if (errorObj.status >= 400 && errorObj.status < 500) {
+        const codeByStatus: Record<number, string> = {
+          403: 'FORBIDDEN',
+          404: 'NOT_FOUND',
+          409: 'CONFLICT',
+        };
+        return new AtpError(
+          errorObj.message || `Request failed with status ${errorObj.status}`,
+          codeByStatus[errorObj.status] ?? 'CLIENT_ERROR',
+          errorObj.status,
           errorObj,
           context
         );

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -132,6 +132,29 @@ const ENV_MAPPINGS = {
 /** Config paths whose env values should be coerced to a number (all others stay strings). */
 const NUMERIC_CONFIG_PATHS = new Set<string>(['port']);
 
+/** Mask a sensitive string for logging, keeping just enough to disambiguate. */
+function maskSensitive(value: string): string {
+  return value.length <= 4 ? '***' : `${value.slice(0, 2)}***`;
+}
+
+/**
+ * Produce a log-safe copy of the configuration: passwords/secrets are fully
+ * redacted, and the identifier/clientId are masked (they are sensitive enough not
+ * to appear in logs verbatim).
+ */
+export function redactConfigForLog(config: IMcpServerConfig): IMcpServerConfig {
+  return {
+    ...config,
+    atproto: {
+      ...config.atproto,
+      ...(config.atproto.identifier && { identifier: maskSensitive(config.atproto.identifier) }),
+      ...(config.atproto.password && { password: '[REDACTED]' }),
+      ...(config.atproto.clientId && { clientId: maskSensitive(config.atproto.clientId) }),
+      ...(config.atproto.clientSecret && { clientSecret: '[REDACTED]' }),
+    },
+  };
+}
+
 /**
  * Configuration manager class
  */
@@ -254,34 +277,42 @@ export class ConfigManager {
   }
 
   /**
+   * Whether the given AT Protocol config carries the credentials required for the
+   * specified auth method. Single source of truth for the credential-presence
+   * check shared by validation, hasAuthentication, and isValidForAuth.
+   */
+  private hasCredentialsFor(authMethod: 'app-password' | 'oauth', atproto: IAtpConfig): boolean {
+    if (authMethod === 'app-password') {
+      return !!(atproto.identifier && atproto.password);
+    }
+    if (authMethod === 'oauth') {
+      return !!(atproto.clientId && atproto.clientSecret);
+    }
+    return false;
+  }
+
+  /**
    * Validate authentication configuration
    * Authentication is now optional - only validate if auth method is specified
    */
   private validateAuthConfiguration(): void {
     const { atproto } = this.config;
 
-    // Skip validation in test environment if credentials are not provided
-    const isTestEnv = process.env['NODE_ENV'] === 'test';
-
     // If no auth method is specified, we're in unauthenticated mode - no validation needed
     if (!atproto.authMethod) {
       return;
     }
 
-    if (atproto.authMethod === 'app-password') {
-      if (!isTestEnv && (!atproto.identifier || !atproto.password)) {
-        throw new ConfigurationError(
-          'App password authentication requires both identifier and password',
-          { authMethod: atproto.authMethod }
-        );
-      }
-    } else if (atproto.authMethod === 'oauth') {
-      if (!isTestEnv && (!atproto.clientId || !atproto.clientSecret)) {
-        throw new ConfigurationError(
-          'OAuth authentication requires both clientId and clientSecret',
-          { authMethod: atproto.authMethod }
-        );
-      }
+    // Skip the credential requirement in the test environment (tests construct
+    // configs without real credentials).
+    const isTestEnv = process.env['NODE_ENV'] === 'test';
+    if (!isTestEnv && !this.hasCredentialsFor(atproto.authMethod, atproto)) {
+      throw new ConfigurationError(
+        atproto.authMethod === 'app-password'
+          ? 'App password authentication requires both identifier and password'
+          : 'OAuth authentication requires both clientId and clientSecret',
+        { authMethod: atproto.authMethod }
+      );
     }
   }
 
@@ -289,16 +320,7 @@ export class ConfigManager {
    * Log configuration (excluding sensitive data)
    */
   private logConfiguration(): void {
-    const safeConfig = {
-      ...this.config,
-      atproto: {
-        ...this.config.atproto,
-        password: this.config.atproto.password ? '[REDACTED]' : undefined,
-        clientSecret: this.config.atproto.clientSecret ? '[REDACTED]' : undefined,
-      },
-    };
-
-    logger.info('Configuration loaded', safeConfig);
+    logger.info('Configuration loaded', redactConfigForLog(this.config));
   }
 
   /**
@@ -348,13 +370,7 @@ export class ConfigManager {
       McpServerConfigSchema.parse(testConfig);
 
       // Additional validation for auth method requirements
-      if (authMethod === 'app-password') {
-        return !!(testConfig.atproto.identifier && testConfig.atproto.password);
-      } else if (authMethod === 'oauth') {
-        return !!(testConfig.atproto.clientId && testConfig.atproto.clientSecret);
-      }
-
-      return true;
+      return this.hasCredentialsFor(authMethod, testConfig.atproto);
     } catch {
       return false;
     }
@@ -365,18 +381,7 @@ export class ConfigManager {
    */
   public hasAuthentication(): boolean {
     const { atproto } = this.config;
-
-    if (!atproto.authMethod) {
-      return false;
-    }
-
-    if (atproto.authMethod === 'app-password') {
-      return !!(atproto.identifier && atproto.password);
-    } else if (atproto.authMethod === 'oauth') {
-      return !!(atproto.clientId && atproto.clientSecret);
-    }
-
-    return false;
+    return atproto.authMethod ? this.hasCredentialsFor(atproto.authMethod, atproto) : false;
   }
 
   /**

--- a/src/utils/firehose-client.ts
+++ b/src/utils/firehose-client.ts
@@ -271,8 +271,10 @@ export class FirehoseClient extends EventEmitter {
   private processEvent(event: IFirehoseEvent): void {
     this.emit('event', event);
 
-    // Notify matching subscriptions
-    for (const subscription of this.subscriptions.values()) {
+    // Iterate a snapshot: a subscription handler may subscribe/unsubscribe during
+    // dispatch, and mutating the Map mid-iteration would otherwise skip a still-
+    // valid subscriber.
+    for (const subscription of Array.from(this.subscriptions.values())) {
       try {
         // Check if subscription matches the event
         if (this.matchesSubscription(event, subscription)) {

--- a/src/utils/firehose-client.ts
+++ b/src/utils/firehose-client.ts
@@ -51,8 +51,16 @@ export class FirehoseClient extends EventEmitter {
   private isShuttingDown = false;
   private heartbeatInterval: NodeJS.Timeout | null = null;
   private reconnectTimer: NodeJS.Timeout | null = null;
+  private stabilityTimer: NodeJS.Timeout | null = null;
   private lastSeq: number | null = null;
+  private lastPongAt = 0;
   private warnedParserNotImplemented = false;
+
+  private static readonly HEARTBEAT_MS = 30000;
+  // A connection must stay open this long before its success "counts" (resets
+  // backoff). Prevents an accept-then-drop relay from zeroing the attempt
+  // counter every cycle and reconnecting ~once/second forever.
+  private static readonly STABILITY_MS = 30000;
 
   constructor(config: IAtpConfig) {
     super();
@@ -72,6 +80,11 @@ export class FirehoseClient extends EventEmitter {
     this.isShuttingDown = false;
 
     try {
+      // Tear down any lingering socket (e.g. a half-open one from a prior
+      // reconnect) before opening a new one, so we never leak the old socket or
+      // leave its listeners attached to this client.
+      this.teardownSocket();
+
       const firehoseUrl = this.getFirehoseUrl();
       this.logger.info('Connecting to AT Protocol firehose', { url: firehoseUrl });
 
@@ -80,10 +93,21 @@ export class FirehoseClient extends EventEmitter {
       this.ws.on('open', () => {
         this.logger.info('Firehose connection established');
         this.isConnecting = false;
-        this.reconnectAttempts = 0;
-        this.reconnectDelay = 1000;
+        this.lastPongAt = Date.now();
         this.startHeartbeat();
         this.emit('connected');
+
+        // Only reset backoff after the connection has proven stable (stayed open
+        // for STABILITY_MS) — not on the open event itself.
+        this.stabilityTimer = setTimeout(() => {
+          this.reconnectAttempts = 0;
+          this.reconnectDelay = 1000;
+        }, FirehoseClient.STABILITY_MS);
+        this.stabilityTimer.unref();
+      });
+
+      this.ws.on('pong', () => {
+        this.lastPongAt = Date.now();
       });
 
       this.ws.on('message', (data: Buffer) => {
@@ -131,12 +155,11 @@ export class FirehoseClient extends EventEmitter {
    */
   async disconnect(): Promise<void> {
     this.isShuttingDown = true;
+    // cleanup() tears down the socket (removes listeners + terminates) and all
+    // timers. This is a full teardown, so also drop subscriptions — otherwise a
+    // later reconnect would replay stale handlers.
     this.cleanup();
-
-    if (this.ws) {
-      this.ws.close();
-      this.ws = null;
-    }
+    this.subscriptions.clear();
 
     this.logger.info('Firehose client disconnected');
     this.emit('disconnected', { code: 1000, reason: 'Client disconnect' });
@@ -169,6 +192,13 @@ export class FirehoseClient extends EventEmitter {
   }
 
   /**
+   * Number of active subscriptions (for status reporting).
+   */
+  getSubscriptionCount(): number {
+    return this.subscriptions.size;
+  }
+
+  /**
    * Get the last processed sequence number
    */
   getLastSeq(): number | null {
@@ -184,8 +214,17 @@ export class FirehoseClient extends EventEmitter {
    */
   private getFirehoseUrl(): string {
     const relay = process.env['ATPROTO_RELAY'] ?? 'wss://bsky.network';
+    // Preserve an explicit ws:// scheme (local relays / tests); https/wss/bare
+    // hosts all map to secure wss://.
+    const scheme = /^ws:\/\//.test(relay) ? 'ws' : 'wss';
     const baseUrl = relay.replace(/^(wss?|https?):\/\//, '');
-    return `wss://${baseUrl}/xrpc/com.atproto.sync.subscribeRepos`;
+    let url = `${scheme}://${baseUrl}/xrpc/com.atproto.sync.subscribeRepos`;
+    // Resume from the last processed sequence on reconnect so events emitted
+    // during the disconnect window are not dropped.
+    if (this.lastSeq != null) {
+      url += `?cursor=${this.lastSeq}`;
+    }
+    return url;
   }
 
   /**
@@ -278,7 +317,10 @@ export class FirehoseClient extends EventEmitter {
     }
 
     this.reconnectAttempts++;
-    const delay = Math.min(this.reconnectDelay * Math.pow(2, this.reconnectAttempts - 1), 30000);
+    const base = Math.min(this.reconnectDelay * Math.pow(2, this.reconnectAttempts - 1), 30000);
+    // Full jitter over [base/2, base] so many clients dropped at once by a relay
+    // restart don't reconnect in lockstep (thundering herd).
+    const delay = Math.round(base / 2 + Math.random() * (base / 2));
 
     this.logger.info('Scheduling firehose reconnection', {
       attempt: this.reconnectAttempts,
@@ -302,15 +344,27 @@ export class FirehoseClient extends EventEmitter {
    */
   private startHeartbeat(): void {
     this.heartbeatInterval = setInterval(() => {
-      if (this.ws?.readyState === WebSocket.OPEN) {
-        this.ws.ping();
+      if (this.ws?.readyState !== WebSocket.OPEN) {
+        return;
       }
-    }, 30000); // Ping every 30 seconds
+
+      // Liveness check: a half-open TCP connection (peer vanished with no
+      // FIN/RST) stays readyState===OPEN forever, so pings vanish and 'close'
+      // never fires. If no pong has arrived within ~2 heartbeat intervals,
+      // terminate the dead socket to trigger the normal reconnect path.
+      if (Date.now() - this.lastPongAt > FirehoseClient.HEARTBEAT_MS * 2) {
+        this.logger.warn('No firehose pong within liveness window; terminating dead connection');
+        this.ws.terminate();
+        return;
+      }
+
+      this.ws.ping();
+    }, FirehoseClient.HEARTBEAT_MS);
     this.heartbeatInterval.unref();
   }
 
   /**
-   * Cleanup resources
+   * Cleanup resources: stop all timers and tear down the socket.
    */
   private cleanup(): void {
     this.isConnecting = false;
@@ -323,6 +377,34 @@ export class FirehoseClient extends EventEmitter {
     if (this.reconnectTimer) {
       clearTimeout(this.reconnectTimer);
       this.reconnectTimer = null;
+    }
+
+    if (this.stabilityTimer) {
+      clearTimeout(this.stabilityTimer);
+      this.stabilityTimer = null;
+    }
+
+    this.teardownSocket();
+  }
+
+  /**
+   * Remove all listeners from the current socket and force-close it.
+   *
+   * Called before opening a new socket and during cleanup so a half-open or
+   * errored socket is never left attached to this client (which would leak the
+   * underlying FD and could double-process events). Because the first of the
+   * error/close pair to fire removes the listeners here, the second never
+   * re-runs cleanup/reconnect — closing the error-then-close double-schedule race.
+   */
+  private teardownSocket(): void {
+    if (this.ws) {
+      this.ws.removeAllListeners();
+      try {
+        this.ws.terminate();
+      } catch {
+        // Socket may already be closed; ignore.
+      }
+      this.ws = null;
     }
   }
 }

--- a/src/utils/firehose-client.ts
+++ b/src/utils/firehose-client.ts
@@ -398,13 +398,19 @@ export class FirehoseClient extends EventEmitter {
    */
   private teardownSocket(): void {
     if (this.ws) {
-      this.ws.removeAllListeners();
+      const sock = this.ws;
+      this.ws = null;
+      sock.removeAllListeners();
+      // A socket terminated while still CONNECTING emits an async 'error'
+      // ("WebSocket was closed before the connection was established"). We just
+      // removed all listeners, so attach a no-op one to swallow it rather than
+      // let it surface as an unhandled error.
+      sock.on('error', () => {});
       try {
-        this.ws.terminate();
+        sock.terminate();
       } catch {
         // Socket may already be closed; ignore.
       }
-      this.ws = null;
     }
   }
 }

--- a/src/utils/security.ts
+++ b/src/utils/security.ts
@@ -90,6 +90,15 @@ export class InputSanitizer {
       const sanitized: any = {};
       for (const [key, value] of Object.entries(obj)) {
         const sanitizedKey = this.sanitizeString(key);
+        // Drop prototype-polluting keys so an attacker-supplied `__proto__`/
+        // `constructor`/`prototype` can't reassign the result's prototype.
+        if (
+          sanitizedKey === '__proto__' ||
+          sanitizedKey === 'constructor' ||
+          sanitizedKey === 'prototype'
+        ) {
+          continue;
+        }
         sanitized[sanitizedKey] = this.sanitizeObject(value);
       }
       return sanitized;

--- a/src/utils/security.ts
+++ b/src/utils/security.ts
@@ -9,6 +9,13 @@ export interface IRateLimitConfig {
   maxRequests: number;
   skipSuccessfulRequests?: boolean;
   skipFailedRequests?: boolean;
+  /**
+   * Maximum number of distinct identifiers tracked at once. When exceeded, the
+   * least-recently-used entry is evicted. Bounds memory so a flood of distinct
+   * (e.g. attacker-controlled) keys cannot exhaust the heap between cleanup
+   * sweeps. Defaults to 50_000.
+   */
+  maxTrackedIdentifiers?: number;
 }
 
 export interface ISecurityConfig {
@@ -135,10 +142,12 @@ export class RateLimiter {
   private config: IRateLimitConfig;
   private logger: Logger;
   private readonly cleanupTimer: NodeJS.Timeout;
+  private readonly maxTrackedIdentifiers: number;
 
   constructor(config: IRateLimitConfig, logger: Logger) {
     this.config = config;
     this.logger = logger;
+    this.maxTrackedIdentifiers = config.maxTrackedIdentifiers ?? 50_000;
 
     // Clean up old entries periodically. unref() so the timer never keeps the
     // process alive on its own.
@@ -159,14 +168,17 @@ export class RateLimiter {
     const now = Date.now();
     const windowStart = now - this.config.windowMs;
 
-    // Get existing requests for this identifier
-    const userRequests = this.requests.get(identifier) || [];
-
-    // Filter out requests outside the current window
+    // Get existing requests for this identifier and drop those outside the window.
+    const userRequests = this.requests.get(identifier) ?? [];
     const recentRequests = userRequests.filter(timestamp => timestamp > windowStart);
+
+    // Delete first so the subsequent set() moves this key to the most-recently-
+    // used position (Map preserves insertion order; last inserted = most recent).
+    this.requests.delete(identifier);
 
     // Check if limit exceeded
     if (recentRequests.length >= this.config.maxRequests) {
+      this.requests.set(identifier, recentRequests);
       this.logger.warn('Rate limit exceeded', {
         identifier,
         requests: recentRequests.length,
@@ -177,6 +189,17 @@ export class RateLimiter {
 
     // Add current request
     recentRequests.push(now);
+
+    // Bound the identifier cardinality: when at capacity and inserting a NEW
+    // key, evict the least-recently-used (oldest-inserted) entry so a flood of
+    // distinct identifiers cannot exhaust memory between cleanup sweeps.
+    if (this.requests.size >= this.maxTrackedIdentifiers) {
+      const lruKey = this.requests.keys().next().value;
+      if (lruKey !== undefined) {
+        this.requests.delete(lruKey);
+      }
+    }
+
     this.requests.set(identifier, recentRequests);
 
     return true;
@@ -198,12 +221,18 @@ export class RateLimiter {
    * Get reset time for identifier
    */
   getResetTime(identifier: string): number {
-    const userRequests = this.requests.get(identifier) || [];
+    const now = Date.now();
+    const windowStart = now - this.config.windowMs;
+    const userRequests = (this.requests.get(identifier) ?? []).filter(
+      timestamp => timestamp > windowStart
+    );
     if (userRequests.length === 0) {
-      return Date.now();
+      return now;
     }
 
-    const oldestRequest = Math.min(...userRequests);
+    // Reduce-based min (no array spread, which can overflow the call stack for
+    // very large arrays).
+    const oldestRequest = userRequests.reduce((min, t) => (t < min ? t : min), Infinity);
     return oldestRequest + this.config.windowMs;
   }
 

--- a/src/utils/url-safety.ts
+++ b/src/utils/url-safety.ts
@@ -190,14 +190,24 @@ export function assertSafePath(filePath: string, baseDir: string): string {
   }
 
   // Resolve symlinks so a link planted inside the base directory cannot point
-  // outside it (the lexical check above only catches `..` traversal). This is
-  // enforced for paths that actually exist; a not-yet-created path has no link to
-  // follow, so an ENOENT is treated as "nothing to resolve".
+  // outside it (the lexical check above only catches `..` traversal). Resolve the
+  // base and the target separately: a missing base means there is nothing to
+  // enforce against (the read will fail anyway), while a missing target is a
+  // not-yet-created path with no link to follow.
+  let realBase: string;
   try {
-    const realBase = realpathSync(resolvedBase);
+    realBase = realpathSync(resolvedBase);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+      return resolved;
+    }
+    throw err;
+  }
+
+  try {
     const realResolved = realpathSync(resolved);
     const realRel = path.relative(realBase, realResolved);
-    if (realRel.startsWith('..') || path.isAbsolute(realRel)) {
+    if (realRel === '' || realRel.startsWith('..') || path.isAbsolute(realRel)) {
       throw new Error(
         `Refusing to access "${filePath}": resolves outside the allowed directory via a symlink (${realBase})`
       );

--- a/src/utils/url-safety.ts
+++ b/src/utils/url-safety.ts
@@ -13,6 +13,7 @@ import https from 'node:https';
 import zlib from 'node:zlib';
 import { type LookupAddress, type LookupOptions, lookup as dnsLookup } from 'node:dns';
 import { isIP, isIPv4, isIPv6 } from 'node:net';
+import { realpathSync } from 'node:fs';
 import path from 'node:path';
 
 function ipv4ToInt(ip: string): number | null {
@@ -122,6 +123,17 @@ function isBlockedIPv6(ip: string): boolean {
   if (b[0] === 0x20 && b[1] === 0x02) {
     return isBlockedIPv4(`${b[2]}.${b[3]}.${b[4]}.${b[5]}`);
   }
+  // NAT64 64:ff9b::/96 — evaluate the embedded IPv4 (last 4 bytes) so a private
+  // IPv4 cannot be smuggled to the resolver as an IPv6 literal.
+  if (
+    b[0] === 0x00 &&
+    b[1] === 0x64 &&
+    b[2] === 0xff &&
+    b[3] === 0x9b &&
+    b.slice(4, 12).every(x => x === 0)
+  ) {
+    return isBlockedIPv4(`${b[12]}.${b[13]}.${b[14]}.${b[15]}`);
+  }
   return false;
 }
 
@@ -176,6 +188,26 @@ export function assertSafePath(filePath: string, baseDir: string): string {
       `Refusing to access "${filePath}": resolved path is outside the allowed directory (${resolvedBase})`
     );
   }
+
+  // Resolve symlinks so a link planted inside the base directory cannot point
+  // outside it (the lexical check above only catches `..` traversal). This is
+  // enforced for paths that actually exist; a not-yet-created path has no link to
+  // follow, so an ENOENT is treated as "nothing to resolve".
+  try {
+    const realBase = realpathSync(resolvedBase);
+    const realResolved = realpathSync(resolved);
+    const realRel = path.relative(realBase, realResolved);
+    if (realRel.startsWith('..') || path.isAbsolute(realRel)) {
+      throw new Error(
+        `Refusing to access "${filePath}": resolves outside the allowed directory via a symlink (${realBase})`
+      );
+    }
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
+      throw err;
+    }
+  }
+
   return resolved;
 }
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -29,10 +29,10 @@ export default defineConfig({
       // actually fails the run. Values are a no-regression ratchet pinned just
       // under current real coverage; raise them as coverage improves.
       thresholds: {
-        branches: 30,
-        functions: 50,
-        lines: 42,
-        statements: 42,
+        branches: 34,
+        functions: 56,
+        lines: 47,
+        statements: 47,
       },
     },
     setupFiles: ['./src/test/setup.ts'],

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,7 +7,8 @@ export default defineConfig({
     environment: 'node',
     coverage: {
       provider: 'v8',
-      reporter: ['text', 'json', 'html'],
+      // 'lcov' is required by the Codecov upload step in ci.yml (coverage/lcov.info).
+      reporter: ['text', 'json', 'html', 'lcov'],
       // Vitest 4.0: Explicitly include source files for coverage
       include: ['src/**/*.{js,ts}'],
       exclude: [
@@ -22,13 +23,16 @@ export default defineConfig({
         '**/*.test.*',
         '**/*.spec.*',
       ],
+      // Vitest 4.x: thresholds must be flat keys (or per-file globs). The old
+      // `thresholds.global` wrapper is treated as a filename glob that matches
+      // nothing, silently disabling enforcement — keep these flat so the gate
+      // actually fails the run. Values are a no-regression ratchet pinned just
+      // under current real coverage; raise them as coverage improves.
       thresholds: {
-        global: {
-          branches: 80,
-          functions: 80,
-          lines: 80,
-          statements: 80,
-        },
+        branches: 30,
+        functions: 50,
+        lines: 42,
+        statements: 42,
       },
     },
     setupFiles: ['./src/test/setup.ts'],


### PR DESCRIPTION
End-to-end review of the codebase with the findings fixed. Each fix is its own commit; bug fixes and security hardening were written test-first. `npm run check` (lint + format + type-check + test), `npm run build`, and the coverage gate all pass — 302 tests (up from 283).

## CI / build / config
- **Coverage gate was a no-op.** `thresholds.global` is ignored in vitest 4.x (treated as a filename glob matching nothing), so the configured 80% gate enforced nothing — real coverage was ~43%. Flattened the thresholds to enforce a real floor (a no-regression ratchet, now ~47% after the new tests) and added `lcov` output for the Codecov upload.
- **Dockerfile couldn't build.** `npm ci --only=production` is impossible here (no `package-lock.json`; drops `tsc`). Rebuilt on pnpm; removed the dead `config/` copy and the bogus `EXPOSE 3000` (this is a stdio server).
- Live Bluesky integration tests now run only on schedule/dispatch, not on every push/PR (they self-document as flaky). Removed the `dist/` release-asset upload (colliding basenames 404 the run). Pinned third-party actions to commit SHAs; moved `pnpm/action-setup` to v4 (its `@v2` tag no longer exists).

## Correctness bugs
- `follow_user` detected existing follows via a 100-record `listRecords` scan, creating duplicate follows for accounts following >100 users. Now uses the authoritative `viewer.following` signal.
- Removed fabricated/incorrect metrics: chunk `getProfiles` to the 25-actor API cap; count mutual connections over the full sample (not a top-10 slice); drop always-`undefined` follower/post counts on `get_followers`/`get_follows`; fetch real `get_custom_feed` metadata via `getFeedGenerator`; correct the `analyze_moderation_status` return type.

## Security
- Rate limiter: cap tracked identifiers (LRU eviction) to bound memory under a key flood; replace `Math.min(...arr)` with a reduce.
- `sanitizeObject` now drops `__proto__`/`constructor`/`prototype` keys. Added tests for the error/input sanitizers, the SSRF guard refusing loopback/private/obfuscated/non-http targets, and the auth gate failing closed without credentials.

## Firehose (dormant behind `FIREHOSE_DECODING_IMPLEMENTED=false`, fixed before a decoder lands)
- Tear down the old socket on reconnect/cleanup (no FD leak / double-processing; closes the error-then-close race); pong-based liveness for half-open connections; reset backoff only after a stability window; jittered backoff; clear subscriptions on disconnect; resume from `lastSeq` cursor. Added real-socket lifecycle tests.

## Refactor
- Consolidated 4× `getCidFromUri`, AT-URI parsing, and 2× `uploadBlob` into `BaseTool`.

## Notes
- One reviewed item (error sanitizer "not wired in") was a **false positive** — it's already in the request path — so it was left unchanged.
- `transformPost`/`extractHashtags` dedup was deferred (meaningful per-site variation; risk > cosmetic gain).
- The coverage floor is a ratchet at current real coverage (~47%), not 80% — raise it as more tests land.
