### PR TITLE
Backfill test coverage and resolve remaining low-severity review findings

### DIFF
--- a/src/__tests__/batch-operations.test.ts
+++ b/src/__tests__/batch-operations.test.ts
@@ -30,6 +30,10 @@ const createMockAtpClient = () => {
         },
       },
     })),
+    // batch_like/batch_repost fetch the post view (CID + viewer state) in one call.
+    getPosts: vi.fn().mockImplementation(async ({ uris }: { uris: string[] }) => ({
+      data: { posts: uris.map((uri: string) => ({ uri, cid: 'cid123', viewer: {} })) },
+    })),
     com: {
       atproto: {
         repo: {
@@ -183,19 +187,15 @@ describe('BatchLikeTool', () => {
 
   it('should handle invalid URIs', async () => {
     const agent = mockClient.getAgent();
-    // Mock getRecord to fail for the second URI
-    agent.com.atproto.repo.getRecord
+    // The post lookup succeeds for the first URI and returns no post for the
+    // second (not found), so that item fails.
+    agent.getPosts
       .mockResolvedValueOnce({
         data: {
-          uri: 'at://did:plc:user1/app.bsky.feed.post/1',
-          cid: 'cid123',
-          value: {
-            text: 'Test post',
-            createdAt: new Date().toISOString(),
-          },
+          posts: [{ uri: 'at://did:plc:user1/app.bsky.feed.post/1', cid: 'cid123', viewer: {} }],
         },
       })
-      .mockRejectedValueOnce(new Error('Post not found'));
+      .mockResolvedValueOnce({ data: { posts: [] } });
 
     const result = await tool.handler({
       uris: [

--- a/src/__tests__/batch-roundtrip.test.ts
+++ b/src/__tests__/batch-roundtrip.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Perf regression test: batch_like / batch_repost already fetch each post via
+ * getPosts (for viewer state), and that response carries the post CID. They must
+ * reuse it for the like/repost subject instead of issuing a second per-item
+ * getRecord round-trip (getCidFromUri).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { BatchLikeTool, BatchRepostTool } from '../tools/implementations/batch-operations-tools.js';
+import type { AtpClient } from '../utils/atp-client.js';
+
+const URI = 'at://did:plc:x/app.bsky.feed.post/p';
+
+function mockClient(posts: unknown[]) {
+  const getPosts = vi.fn().mockResolvedValue({ data: { posts } });
+  const getRecord = vi.fn();
+  const createRecord = vi.fn().mockResolvedValue({ data: { uri: 'at://rec', cid: 'reccid' } });
+  const agent = {
+    getPosts,
+    com: { atproto: { repo: { getRecord, createRecord } } },
+    session: { did: 'did:plc:self' },
+  };
+  const client = {
+    getAgent: vi.fn().mockReturnValue(agent),
+    isAuthenticated: vi.fn().mockReturnValue(true),
+    hasCredentials: vi.fn().mockReturnValue(true),
+    executeAuthenticatedRequest: vi.fn().mockImplementation(async (op: () => unknown) => {
+      try {
+        return { success: true, data: await op() };
+      } catch (error) {
+        return { success: false, error };
+      }
+    }),
+  } as unknown as AtpClient;
+  return { client, getPosts, getRecord, createRecord };
+}
+
+describe('batch tools reuse the getPosts CID (no redundant getRecord)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('batch_like uses the post CID from getPosts and never calls getRecord', async () => {
+    const { client, getPosts, getRecord, createRecord } = mockClient([
+      { uri: URI, cid: 'postcid', viewer: {} },
+    ]);
+    const result = await new BatchLikeTool(client).handler({ uris: [URI] });
+
+    expect(getRecord).not.toHaveBeenCalled();
+    expect(getPosts).toHaveBeenCalledTimes(1);
+    expect(createRecord).toHaveBeenCalledWith(
+      expect.objectContaining({
+        collection: 'app.bsky.feed.like',
+        record: expect.objectContaining({ subject: { uri: URI, cid: 'postcid' } }),
+      })
+    );
+    expect(result.summary.succeeded).toBe(1);
+  });
+
+  it('batch_like reports alreadyLiked from viewer.like without creating a record', async () => {
+    const { client, createRecord } = mockClient([
+      { uri: URI, cid: 'postcid', viewer: { like: 'at://like/1' } },
+    ]);
+    const result = await new BatchLikeTool(client).handler({ uris: [URI] });
+
+    expect(createRecord).not.toHaveBeenCalled();
+    expect(result.results[0]?.alreadyLiked).toBe(true);
+  });
+
+  it('batch_repost uses the post CID from getPosts and never calls getRecord', async () => {
+    const { client, getRecord, createRecord } = mockClient([
+      { uri: URI, cid: 'postcid', viewer: {} },
+    ]);
+    await new BatchRepostTool(client).handler({ uris: [URI] });
+
+    expect(getRecord).not.toHaveBeenCalled();
+    expect(createRecord).toHaveBeenCalledWith(
+      expect.objectContaining({
+        collection: 'app.bsky.feed.repost',
+        record: expect.objectContaining({ subject: { uri: URI, cid: 'postcid' } }),
+      })
+    );
+  });
+});

--- a/src/__tests__/media-tools.test.ts
+++ b/src/__tests__/media-tools.test.ts
@@ -1,0 +1,344 @@
+/**
+ * Unit tests for the media tools.
+ *
+ * These lock the on-the-wire shapes produced by:
+ * - UploadImageTool       (src/tools/implementations/media-tools.ts)
+ * - CreateRichTextPostTool(src/tools/implementations/media-tools.ts)
+ * - GenerateAltTextTool   (src/tools/implementations/generate-alt-text-tool.ts)
+ * - ExtractMediaFromPostTool (src/tools/implementations/rich-media-tools.ts)
+ *
+ * The path-based tools read real files under mediaBaseDir() (ATPROTO_MEDIA_DIR
+ * or cwd), guarded by assertSafePath. Each test that exercises a path creates a
+ * real temp dir + file and points ATPROTO_MEDIA_DIR at it, so readFile succeeds
+ * and traversal can be genuinely refused. generate_link_preview is intentionally
+ * NOT tested here because it performs a real network fetch via safeFetch.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { CreateRichTextPostTool, UploadImageTool } from '../tools/implementations/media-tools.js';
+import { GenerateAltTextTool } from '../tools/implementations/generate-alt-text-tool.js';
+import { ExtractMediaFromPostTool } from '../tools/implementations/rich-media-tools.js';
+import type { AtpClient } from '../utils/atp-client.js';
+
+// Routes an operation the way the real AtpClient does: success -> { success,
+// data }, throw -> { success: false, error } (BaseTool re-throws error).
+const wrap = async (op: () => unknown) => {
+  try {
+    return { success: true, data: await op() };
+  } catch (error) {
+    return { success: false, error };
+  }
+};
+
+function makeClient(agent: any, opts: { authenticated?: boolean } = {}): AtpClient {
+  return {
+    getAgent: vi.fn().mockReturnValue(agent),
+    isAuthenticated: vi.fn().mockReturnValue(opts.authenticated ?? true),
+    hasCredentials: vi.fn().mockReturnValue(true),
+    executeAuthenticatedRequest: vi.fn().mockImplementation(wrap),
+    executePublicRequest: vi.fn().mockImplementation(wrap),
+  } as unknown as AtpClient;
+}
+
+describe('UploadImageTool', () => {
+  let baseDir: string;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    baseDir = mkdtempSync(join(tmpdir(), 'atproto-media-'));
+    process.env['ATPROTO_MEDIA_DIR'] = baseDir;
+  });
+
+  afterEach(() => {
+    delete process.env['ATPROTO_MEDIA_DIR'];
+    rmSync(baseDir, { recursive: true, force: true });
+  });
+
+  it('derives image/jpeg from a .jpg extension and uploads the file buffer with that encoding', async () => {
+    writeFileSync(join(baseDir, 'photo.jpg'), Buffer.from('fake-jpeg-bytes'));
+
+    const uploadBlob = vi.fn().mockResolvedValue({
+      data: { blob: { ref: { toString: () => 'bafkreijpg' }, mimeType: 'image/jpeg', size: 15 } },
+    });
+    const client = makeClient({ uploadBlob });
+    const tool = new UploadImageTool(client);
+
+    const result = await tool.handler({ filePath: 'photo.jpg', altText: 'a photo' });
+
+    // The blob is uploaded with the MIME derived from the extension, and the
+    // payload is the real file's bytes (not a string path).
+    expect(uploadBlob).toHaveBeenCalledTimes(1);
+    const [blobArg, optsArg] = uploadBlob.mock.calls[0];
+    expect(Buffer.isBuffer(blobArg)).toBe(true);
+    expect(blobArg.toString()).toBe('fake-jpeg-bytes');
+    expect(optsArg).toEqual({ encoding: 'image/jpeg' });
+
+    expect(result.success).toBe(true);
+    expect(result.image.blob).toEqual(
+      expect.objectContaining({ type: 'blob', ref: 'bafkreijpg', mimeType: 'image/jpeg', size: 15 })
+    );
+    expect(result.image.alt).toBe('a photo');
+  });
+
+  it('derives image/png from a .png extension', async () => {
+    writeFileSync(join(baseDir, 'pic.png'), Buffer.from('fake-png'));
+
+    const uploadBlob = vi.fn().mockResolvedValue({
+      data: { blob: { ref: { toString: () => 'bafkreipng' }, mimeType: 'image/png', size: 8 } },
+    });
+    const client = makeClient({ uploadBlob });
+    const tool = new UploadImageTool(client);
+
+    const result = await tool.handler({ filePath: 'pic.png' });
+
+    expect(uploadBlob.mock.calls[0][1]).toEqual({ encoding: 'image/png' });
+    expect(result.image.blob.mimeType).toBe('image/png');
+    // No altText provided -> empty string, never undefined.
+    expect(result.image.alt).toBe('');
+  });
+
+  it('refuses a path that escapes the media base dir (path traversal) and never uploads', async () => {
+    const uploadBlob = vi.fn();
+    const client = makeClient({ uploadBlob });
+    const tool = new UploadImageTool(client);
+
+    // '../../etc/hosts' resolves outside baseDir; assertSafePath throws and the
+    // error is surfaced (formatError wraps it but preserves the message).
+    await expect(tool.handler({ filePath: '../../etc/hosts.jpg' })).rejects.toThrow(
+      /outside the allowed directory/
+    );
+    expect(uploadBlob).not.toHaveBeenCalled();
+  });
+
+  it('rejects an unsupported file extension without uploading', async () => {
+    writeFileSync(join(baseDir, 'doc.txt'), Buffer.from('not an image'));
+    const uploadBlob = vi.fn();
+    const client = makeClient({ uploadBlob });
+    const tool = new UploadImageTool(client);
+
+    await expect(tool.handler({ filePath: 'doc.txt' })).rejects.toThrow(/Unsupported image format/);
+    expect(uploadBlob).not.toHaveBeenCalled();
+  });
+});
+
+describe('CreateRichTextPostTool', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('posts the text and maps a link facet to the on-the-wire app.bsky.richtext.facet#link shape', async () => {
+    const post = vi.fn().mockResolvedValue({
+      uri: 'at://did:plc:self/app.bsky.feed.post/abc',
+      cid: 'cidpost',
+    });
+    const client = makeClient({ post });
+    const tool = new CreateRichTextPostTool(client);
+
+    const text = 'see https://example.com';
+    const result = await tool.handler({
+      text,
+      facets: [
+        {
+          index: { byteStart: 4, byteEnd: 23 },
+          features: [{ type: 'link', value: 'https://example.com' }],
+        },
+      ],
+    });
+
+    expect(post).toHaveBeenCalledTimes(1);
+    const record = post.mock.calls[0][0];
+    expect(record.text).toBe(text);
+    expect(typeof record.createdAt).toBe('string');
+    // The facets array is non-empty and the feature was mapped to the AT facet $type.
+    expect(Array.isArray(record.facets)).toBe(true);
+    expect(record.facets).toHaveLength(1);
+    expect(record.facets[0].features[0]).toEqual({
+      $type: 'app.bsky.richtext.facet#link',
+      uri: 'https://example.com',
+    });
+    expect(record.facets[0].index).toEqual({ byteStart: 4, byteEnd: 23 });
+
+    expect(result.success).toBe(true);
+    expect(result.post).toEqual(
+      expect.objectContaining({ uri: 'at://did:plc:self/app.bsky.feed.post/abc', cid: 'cidpost' })
+    );
+  });
+
+  it('posts plain text with no facets when none are supplied', async () => {
+    const post = vi.fn().mockResolvedValue({
+      uri: 'at://did:plc:self/app.bsky.feed.post/plain',
+      cid: 'cidplain',
+    });
+    const client = makeClient({ post });
+    const tool = new CreateRichTextPostTool(client);
+
+    await tool.handler({ text: 'just words' });
+
+    const record = post.mock.calls[0][0];
+    expect(record.text).toBe('just words');
+    // facets is only attached when facets were provided; bare text -> undefined.
+    expect(record.facets).toBeUndefined();
+    expect(record.embed).toBeUndefined();
+  });
+
+  it('builds an app.bsky.embed.record embed from a record reference', async () => {
+    const post = vi.fn().mockResolvedValue({
+      uri: 'at://did:plc:self/app.bsky.feed.post/q',
+      cid: 'cidq',
+    });
+    const client = makeClient({ post });
+    const tool = new CreateRichTextPostTool(client);
+
+    await tool.handler({
+      text: 'quoting this',
+      embed: {
+        type: 'record',
+        record: { uri: 'at://did:plc:other/app.bsky.feed.post/x', cid: 'cidx' },
+      },
+    });
+
+    const record = post.mock.calls[0][0];
+    expect(record.embed).toEqual({
+      $type: 'app.bsky.embed.record',
+      record: { uri: 'at://did:plc:other/app.bsky.feed.post/x', cid: 'cidx' },
+    });
+  });
+});
+
+describe('GenerateAltTextTool', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns guidance (no network) including dos/donts and incorporates context', async () => {
+    // PUBLIC tool: works even when unauthenticated, never touches the agent.
+    const client = makeClient({}, { authenticated: false });
+    const tool = new GenerateAltTextTool(client);
+
+    const result = await tool.handler({
+      imageUrl: 'https://example.com/cat.jpg',
+      context: 'a cat on a sofa',
+    });
+
+    expect(result.success).toBe(true);
+    expect(typeof result.altText).toBe('string');
+    expect(result.altText.length).toBeGreaterThan(0);
+    expect(result.guidelines.dos.length).toBeGreaterThan(0);
+    expect(result.guidelines.donts.length).toBeGreaterThan(0);
+    // The provided context is echoed into the suggestions.
+    expect(result.suggestions.some((s: string) => s.includes('a cat on a sofa'))).toBe(true);
+    // It never calls the agent (no vision model wired in).
+    expect(client.getAgent as any).not.toHaveBeenCalled();
+  });
+
+  it('truncates altText to the requested maxLength', async () => {
+    const client = makeClient({}, { authenticated: false });
+    const tool = new GenerateAltTextTool(client);
+
+    const result = await tool.handler({ imageUrl: 'https://example.com/x.jpg', maxLength: 20 });
+
+    expect(result.altText.length).toBeLessThanOrEqual(20);
+    expect(result.altText.endsWith('...')).toBe(true);
+  });
+
+  it('rejects when neither imageUrl nor imageData is provided (zod refine)', async () => {
+    const client = makeClient({}, { authenticated: false });
+    const tool = new GenerateAltTextTool(client);
+
+    await expect(tool.handler({ context: 'no image here' })).rejects.toThrow();
+  });
+});
+
+describe('ExtractMediaFromPostTool', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('reads the post embed via agent.getPostThread and extracts images with alt text', async () => {
+    const uri = 'at://did:plc:author/app.bsky.feed.post/p1';
+    const getPostThread = vi.fn().mockResolvedValue({
+      data: {
+        thread: {
+          post: {
+            uri,
+            embed: {
+              $type: 'app.bsky.embed.images#view',
+              images: [
+                {
+                  fullsize: 'https://cdn.example.com/full.jpg',
+                  thumb: 'https://cdn.example.com/thumb.jpg',
+                  alt: 'a sunset',
+                  aspectRatio: { width: 1200, height: 800 },
+                },
+              ],
+            },
+          },
+        },
+      },
+    });
+    // ENHANCED tool with an authenticated client uses executeAuthenticatedRequest.
+    const client = makeClient({ getPostThread });
+    const tool = new ExtractMediaFromPostTool(client);
+
+    const result = await tool.handler({ uri });
+
+    expect(getPostThread).toHaveBeenCalledWith(expect.objectContaining({ uri }));
+    expect(result.success).toBe(true);
+    expect(result.media.images).toHaveLength(1);
+    expect(result.media.images[0]).toEqual(
+      expect.objectContaining({
+        uri: 'https://cdn.example.com/full.jpg',
+        alt: 'a sunset',
+        aspectRatio: { width: 1200, height: 800 },
+      })
+    );
+    expect(result.media.videos).toHaveLength(0);
+    expect(result.media.externalLinks).toHaveLength(0);
+  });
+
+  it('extracts an external link embed and works for an unauthenticated (public) caller', async () => {
+    const uri = 'at://did:plc:author/app.bsky.feed.post/p2';
+    const getPostThread = vi.fn().mockResolvedValue({
+      data: {
+        thread: {
+          post: {
+            uri,
+            embed: {
+              $type: 'app.bsky.embed.external#view',
+              external: {
+                uri: 'https://news.example.com/story',
+                title: 'Headline',
+                description: 'A description',
+                thumb: 'https://news.example.com/thumb.jpg',
+              },
+            },
+          },
+        },
+      },
+    });
+    const client = makeClient({ getPostThread }, { authenticated: false });
+    const tool = new ExtractMediaFromPostTool(client);
+
+    const result = await tool.handler({ uri });
+
+    // Unauthenticated ENHANCED mode routes through executePublicRequest.
+    expect(client.executePublicRequest as any).toHaveBeenCalled();
+    expect(result.media.externalLinks).toHaveLength(1);
+    expect(result.media.externalLinks[0]).toEqual(
+      expect.objectContaining({
+        uri: 'https://news.example.com/story',
+        title: 'Headline',
+        description: 'A description',
+      })
+    );
+    expect(result.media.images).toHaveLength(0);
+  });
+
+  it('rejects a non-AT-URI before calling getPostThread', async () => {
+    const getPostThread = vi.fn();
+    const client = makeClient({ getPostThread });
+    const tool = new ExtractMediaFromPostTool(client);
+
+    await expect(tool.handler({ uri: 'https://example.com/not-at-uri' })).rejects.toThrow(
+      /AT Protocol URI/
+    );
+    expect(getPostThread).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/moderation-tools.test.ts
+++ b/src/__tests__/moderation-tools.test.ts
@@ -1,0 +1,280 @@
+/**
+ * Unit tests for the content-moderation tools.
+ *
+ * These lock the on-the-wire shapes the tools send to the AT Protocol SDK:
+ *  - mute/unmute call agent.mute/unmute with the (un-resolved) actor.
+ *  - block creates an app.bsky.graph.block record whose subject is the resolved DID.
+ *  - unblock resolves the existing block record URI from getProfile's
+ *    viewer.blocking, parses the rkey, and deletes the block record by rkey.
+ *  - report_content/report_user call com.atproto.moderation.createReport with the
+ *    correct reasonType NSID and subject (strongRef vs repoRef).
+ *  - analyze_moderation_status (ENHANCED) works unauthenticated and surfaces labels.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  MuteUserTool,
+  UnmuteUserTool,
+  BlockUserTool,
+  UnblockUserTool,
+  ReportContentTool,
+  ReportUserTool,
+  AnalyzeModerationStatusTool,
+} from '../tools/implementations/moderation-tools.js';
+import type { AtpClient } from '../utils/atp-client.js';
+
+const wrap = async (op: () => unknown) => {
+  try {
+    return { success: true, data: await op() };
+  } catch (error) {
+    return { success: false, error };
+  }
+};
+
+function makeClient(agent: any, opts: { authenticated?: boolean } = {}): AtpClient {
+  return {
+    getAgent: vi.fn().mockReturnValue(agent),
+    isAuthenticated: vi.fn().mockReturnValue(opts.authenticated ?? true),
+    hasCredentials: vi.fn().mockReturnValue(true),
+    executeAuthenticatedRequest: vi.fn().mockImplementation(wrap),
+    executePublicRequest: vi.fn().mockImplementation(wrap),
+  } as unknown as AtpClient;
+}
+
+describe('MuteUserTool', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('calls agent.mute with the resolved actor and reports success', async () => {
+    const mute = vi.fn().mockResolvedValue({ data: { did: 'did:plc:target' } });
+    const agent = { mute, session: { did: 'did:plc:self' } };
+    const tool = new MuteUserTool(makeClient(agent));
+
+    const result = await tool.handler({ actor: 'did:plc:target' });
+
+    expect(mute).toHaveBeenCalledTimes(1);
+    // mute/unmute take the actor as-is (a DID, no resolveHandle round-trip).
+    expect(mute).toHaveBeenCalledWith('did:plc:target');
+    expect(result.success).toBe(true);
+    expect(result.mutedUser.actor).toBe('did:plc:target');
+  });
+});
+
+describe('UnmuteUserTool', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('calls agent.unmute with the resolved actor and reports success', async () => {
+    const unmute = vi.fn().mockResolvedValue({ data: { did: 'did:plc:target' } });
+    const agent = { unmute, session: { did: 'did:plc:self' } };
+    const tool = new UnmuteUserTool(makeClient(agent));
+
+    const result = await tool.handler({ actor: 'did:plc:target' });
+
+    expect(unmute).toHaveBeenCalledTimes(1);
+    expect(unmute).toHaveBeenCalledWith('did:plc:target');
+    expect(result.success).toBe(true);
+    expect(result.unmutedUser.actor).toBe('did:plc:target');
+  });
+});
+
+describe('BlockUserTool', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('creates a block record whose subject is the resolved DID', async () => {
+    const create = vi.fn().mockResolvedValue({
+      uri: 'at://did:plc:self/app.bsky.graph.block/blk1',
+      cid: 'cidblk',
+    });
+    const agent = {
+      app: { bsky: { graph: { block: { create } } } },
+      session: { did: 'did:plc:self' },
+    };
+    const tool = new BlockUserTool(makeClient(agent));
+
+    const result = await tool.handler({ actor: 'did:plc:target' });
+
+    expect(create).toHaveBeenCalledTimes(1);
+    // First arg is the repo descriptor (the authed user's repo).
+    expect(create.mock.calls[0][0]).toEqual(expect.objectContaining({ repo: 'did:plc:self' }));
+    // Second arg is the record: subject must be the resolved DID, with a createdAt.
+    const record = create.mock.calls[0][1];
+    expect(record).toEqual(expect.objectContaining({ subject: 'did:plc:target' }));
+    expect(typeof record.createdAt).toBe('string');
+
+    expect(result.success).toBe(true);
+    expect(result.blockedUser.uri).toBe('at://did:plc:self/app.bsky.graph.block/blk1');
+  });
+});
+
+describe('UnblockUserTool', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('parses the rkey from viewer.blocking and deletes the block record', async () => {
+    const blockUri = 'at://did:plc:self/app.bsky.graph.block/blk1';
+    const getProfile = vi
+      .fn()
+      .mockResolvedValue({ data: { did: 'did:plc:target', viewer: { blocking: blockUri } } });
+    const del = vi.fn().mockResolvedValue(undefined);
+    const agent = {
+      getProfile,
+      app: { bsky: { graph: { block: { delete: del } } } },
+      session: { did: 'did:plc:self' },
+    };
+    const tool = new UnblockUserTool(makeClient(agent));
+
+    const result = await tool.handler({ actor: 'did:plc:target' });
+
+    expect(getProfile).toHaveBeenCalledWith({ actor: 'did:plc:target' });
+    expect(del).toHaveBeenCalledTimes(1);
+    // rkey is the last URI segment ('blk1'); delete targets the authed user's repo.
+    expect(del).toHaveBeenCalledWith(
+      expect.objectContaining({ repo: 'did:plc:self', rkey: 'blk1' })
+    );
+    expect(result.success).toBe(true);
+    expect(result.unblockedUser.actor).toBe('did:plc:target');
+  });
+
+  it('reports not-blocked and does not delete when viewer.blocking is absent', async () => {
+    const getProfile = vi.fn().mockResolvedValue({ data: { did: 'did:plc:target', viewer: {} } });
+    const del = vi.fn().mockResolvedValue(undefined);
+    const agent = {
+      getProfile,
+      app: { bsky: { graph: { block: { delete: del } } } },
+      session: { did: 'did:plc:self' },
+    };
+    const tool = new UnblockUserTool(makeClient(agent));
+
+    const result = await tool.handler({ actor: 'did:plc:target' });
+
+    expect(del).not.toHaveBeenCalled();
+    expect(result.success).toBe(false);
+    expect(result.message).toMatch(/not currently blocked/i);
+  });
+});
+
+describe('ReportContentTool', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('reports content with a strongRef subject and the mapped reasonType NSID', async () => {
+    const createReport = vi.fn().mockResolvedValue({ data: { id: 4242 } });
+    const agent = {
+      com: { atproto: { moderation: { createReport } } },
+      session: { did: 'did:plc:self' },
+    };
+    const tool = new ReportContentTool(makeClient(agent));
+
+    const uri = 'at://did:plc:target/app.bsky.feed.post/abc';
+    const result = await tool.handler({
+      subject: { uri, cid: 'bafycid' },
+      reasonType: 'spam',
+      reason: 'lots of spam',
+    });
+
+    expect(createReport).toHaveBeenCalledTimes(1);
+    const payload = createReport.mock.calls[0][0];
+    expect(payload.reasonType).toBe('com.atproto.moderation.defs#reasonSpam');
+    expect(payload.reason).toBe('lots of spam');
+    expect(payload.subject).toEqual({
+      $type: 'com.atproto.repo.strongRef',
+      uri,
+      cid: 'bafycid',
+    });
+    expect(result.success).toBe(true);
+    expect(result.reportId).toBe('4242');
+    expect(result.reportDetails.subject).toBe(uri);
+  });
+
+  it('maps the violation reasonType to reasonViolation NSID', async () => {
+    const createReport = vi.fn().mockResolvedValue({ data: { id: 7 } });
+    const agent = {
+      com: { atproto: { moderation: { createReport } } },
+      session: { did: 'did:plc:self' },
+    };
+    const tool = new ReportContentTool(makeClient(agent));
+
+    await tool.handler({
+      subject: { uri: 'at://did:plc:target/app.bsky.feed.post/xyz', cid: 'bafycid2' },
+      reasonType: 'violation',
+    });
+
+    expect(createReport.mock.calls[0][0].reasonType).toBe(
+      'com.atproto.moderation.defs#reasonViolation'
+    );
+  });
+});
+
+describe('ReportUserTool', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('reports a user with a repoRef subject (resolved DID) and the mapped reasonType NSID', async () => {
+    const createReport = vi.fn().mockResolvedValue({ data: { id: 99 } });
+    const agent = {
+      com: { atproto: { moderation: { createReport } } },
+      session: { did: 'did:plc:self' },
+    };
+    const tool = new ReportUserTool(makeClient(agent));
+
+    const result = await tool.handler({
+      actor: 'did:plc:target',
+      reasonType: 'misleading',
+      reason: 'impersonation',
+    });
+
+    expect(createReport).toHaveBeenCalledTimes(1);
+    const payload = createReport.mock.calls[0][0];
+    expect(payload.reasonType).toBe('com.atproto.moderation.defs#reasonMisleading');
+    expect(payload.reason).toBe('impersonation');
+    expect(payload.subject).toEqual({
+      $type: 'com.atproto.admin.defs#repoRef',
+      did: 'did:plc:target',
+    });
+    expect(result.success).toBe(true);
+    expect(result.reportId).toBe('99');
+    expect(result.reportDetails.actor).toBe('did:plc:target');
+  });
+});
+
+describe('AnalyzeModerationStatusTool', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns labels from the profile and works unauthenticated (ENHANCED)', async () => {
+    const getProfile = vi.fn().mockResolvedValue({
+      data: {
+        did: 'did:plc:target',
+        viewer: { muted: false },
+        labels: [
+          {
+            src: 'did:plc:labeler',
+            uri: 'at://did:plc:target',
+            val: 'nsfw',
+            cts: '2024-01-01T00:00:00Z',
+          },
+        ],
+      },
+    });
+    const agent = { getProfile };
+    const client = makeClient(agent, { authenticated: false });
+    const tool = new AnalyzeModerationStatusTool(client);
+
+    const result = await tool.handler({ subject: 'did:plc:target' });
+
+    // ENHANCED tools fall back to the public request path when unauthenticated.
+    expect(client.executePublicRequest).toHaveBeenCalled();
+    expect(client.executeAuthenticatedRequest).not.toHaveBeenCalled();
+    expect(getProfile).toHaveBeenCalledWith({ actor: 'did:plc:target' });
+
+    expect(result.success).toBe(true);
+    expect(result.subjectType).toBe('user');
+    expect(result.moderation.labels).toEqual([
+      {
+        src: 'did:plc:labeler',
+        uri: 'at://did:plc:target',
+        val: 'nsfw',
+        cts: '2024-01-01T00:00:00Z',
+      },
+    ]);
+    // An nsfw label drives the analysis to a content-warning / warning state.
+    expect(result.analysis.isNSFW).toBe(true);
+    expect(result.analysis.hasContentWarnings).toBe(true);
+    expect(result.analysis.safetyLevel).toBe('warning');
+  });
+});

--- a/src/__tests__/social-graph.test.ts
+++ b/src/__tests__/social-graph.test.ts
@@ -1,0 +1,288 @@
+/**
+ * Unit tests for the social graph read tools (get_followers / get_follows /
+ * get_notifications).
+ *
+ * These lock the on-the-wire contract for the AppView read calls: the actor,
+ * limit, and cursor params are passed straight through to the agent method, the
+ * returned ProfileView/notification entries are mapped to the documented output
+ * shape, and the response cursor (and hasMore flag derived from it) is
+ * propagated. GetFollowers/GetFollows are ENHANCED (work unauthenticated via
+ * executePublicRequest); GetNotifications is PRIVATE (requires auth).
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  GetFollowersTool,
+  GetFollowsTool,
+  GetNotificationsTool,
+} from '../tools/implementations/social-graph-tools.js';
+import type { AtpClient } from '../utils/atp-client.js';
+
+const wrap = async (op: () => unknown) => {
+  try {
+    return { success: true, data: await op() };
+  } catch (error) {
+    return { success: false, error };
+  }
+};
+
+function makeClient(agent: any, opts: { authenticated?: boolean } = {}): AtpClient {
+  return {
+    getAgent: vi.fn().mockReturnValue(agent),
+    isAuthenticated: vi.fn().mockReturnValue(opts.authenticated ?? true),
+    hasCredentials: vi.fn().mockReturnValue(true),
+    executeAuthenticatedRequest: vi.fn().mockImplementation(wrap),
+    executePublicRequest: vi.fn().mockImplementation(wrap),
+  } as unknown as AtpClient;
+}
+
+const sampleProfile = (suffix: string) => ({
+  did: `did:plc:${suffix}`,
+  handle: `${suffix}.bsky.social`,
+  displayName: `User ${suffix}`,
+  description: `bio ${suffix}`,
+  avatar: `https://cdn.example/${suffix}/avatar.jpg`,
+  banner: `https://cdn.example/${suffix}/banner.jpg`,
+  indexedAt: '2026-01-01T00:00:00.000Z',
+  // Field that must NOT leak into the mapped output (ProfileView has no counts).
+  viewer: { following: 'at://x' },
+});
+
+describe('GetFollowersTool', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('passes actor/limit/cursor to agent.getFollowers, maps profiles, and propagates cursor', async () => {
+    const getFollowers = vi.fn().mockResolvedValue({
+      data: {
+        followers: [sampleProfile('alice'), sampleProfile('bob')],
+        cursor: 'next',
+      },
+    });
+    const client = makeClient({ getFollowers });
+    const tool = new GetFollowersTool(client);
+
+    const result = await tool.handler({
+      actor: 'did:plc:target',
+      limit: 25,
+      cursor: 'page2',
+    });
+
+    // Params are forwarded verbatim to the AppView call.
+    expect(getFollowers).toHaveBeenCalledWith({
+      actor: 'did:plc:target',
+      limit: 25,
+      cursor: 'page2',
+    });
+
+    // ENHANCED tool authenticated -> routes through executeAuthenticatedRequest.
+    expect(client.executeAuthenticatedRequest).toHaveBeenCalled();
+
+    expect(result.success).toBe(true);
+    expect(result.actor).toBe('did:plc:target');
+    expect(result.cursor).toBe('next');
+    expect(result.hasMore).toBe(true);
+    expect(result.followers).toHaveLength(2);
+
+    const [first] = result.followers;
+    expect(first).toEqual({
+      did: 'did:plc:alice',
+      handle: 'alice.bsky.social',
+      displayName: 'User alice',
+      description: 'bio alice',
+      avatar: 'https://cdn.example/alice/avatar.jpg',
+      banner: 'https://cdn.example/alice/banner.jpg',
+      indexedAt: '2026-01-01T00:00:00.000Z',
+    });
+    // ProfileView extras (e.g. viewer / counts) are intentionally dropped.
+    expect(first).not.toHaveProperty('viewer');
+    expect(first).not.toHaveProperty('followersCount');
+  });
+
+  it('applies the default limit of 50 and reports hasMore=false when no cursor is returned', async () => {
+    const getFollowers = vi.fn().mockResolvedValue({
+      data: { followers: [], cursor: undefined },
+    });
+    const client = makeClient({ getFollowers });
+    const tool = new GetFollowersTool(client);
+
+    const result = await tool.handler({ actor: 'did:plc:target' });
+
+    expect(getFollowers).toHaveBeenCalledWith({
+      actor: 'did:plc:target',
+      limit: 50,
+      cursor: undefined,
+    });
+    expect(result.cursor).toBeUndefined();
+    expect(result.hasMore).toBe(false);
+    expect(result.followers).toEqual([]);
+  });
+
+  it('works unauthenticated via executePublicRequest (ENHANCED mode)', async () => {
+    const getFollowers = vi.fn().mockResolvedValue({
+      data: { followers: [sampleProfile('alice')], cursor: 'c' },
+    });
+    const client = makeClient({ getFollowers }, { authenticated: false });
+    const tool = new GetFollowersTool(client);
+
+    const result = await tool.handler({ actor: 'did:plc:target', limit: 10 });
+
+    expect(client.executePublicRequest).toHaveBeenCalled();
+    expect(client.executeAuthenticatedRequest).not.toHaveBeenCalled();
+    expect(getFollowers).toHaveBeenCalledWith({
+      actor: 'did:plc:target',
+      limit: 10,
+      cursor: undefined,
+    });
+    expect(result.success).toBe(true);
+    expect(result.followers).toHaveLength(1);
+  });
+});
+
+describe('GetFollowsTool', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('passes actor/limit/cursor to agent.getFollows, maps follows, and propagates cursor', async () => {
+    const getFollows = vi.fn().mockResolvedValue({
+      data: {
+        follows: [sampleProfile('carol')],
+        cursor: 'more',
+      },
+    });
+    const client = makeClient({ getFollows });
+    const tool = new GetFollowsTool(client);
+
+    const result = await tool.handler({
+      actor: 'did:plc:target',
+      limit: 5,
+      cursor: 'startHere',
+    });
+
+    expect(getFollows).toHaveBeenCalledWith({
+      actor: 'did:plc:target',
+      limit: 5,
+      cursor: 'startHere',
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.actor).toBe('did:plc:target');
+    expect(result.cursor).toBe('more');
+    expect(result.hasMore).toBe(true);
+    expect(result.follows).toEqual([
+      {
+        did: 'did:plc:carol',
+        handle: 'carol.bsky.social',
+        displayName: 'User carol',
+        description: 'bio carol',
+        avatar: 'https://cdn.example/carol/avatar.jpg',
+        banner: 'https://cdn.example/carol/banner.jpg',
+        indexedAt: '2026-01-01T00:00:00.000Z',
+      },
+    ]);
+  });
+});
+
+describe('GetNotificationsTool', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  const sampleNotification = () => ({
+    uri: 'at://did:plc:liker/app.bsky.feed.like/abc',
+    cid: 'cidnotif',
+    author: {
+      did: 'did:plc:liker',
+      handle: 'liker.bsky.social',
+      displayName: 'Liker',
+      description: 'fan',
+      avatar: 'https://cdn.example/liker.jpg',
+      followersCount: 10,
+      followsCount: 20,
+      postsCount: 5,
+    },
+    reason: 'like',
+    record: { $type: 'app.bsky.feed.like' },
+    isRead: false,
+    indexedAt: '2026-02-02T00:00:00.000Z',
+    labels: [],
+  });
+
+  it('passes limit/cursor/seenAt to agent.listNotifications, maps items, and propagates cursor + seenAt', async () => {
+    const listNotifications = vi.fn().mockResolvedValue({
+      data: {
+        notifications: [sampleNotification()],
+        cursor: 'notifNext',
+        seenAt: '2026-02-01T00:00:00.000Z',
+      },
+    });
+    const client = makeClient({ listNotifications }, { authenticated: true });
+    const tool = new GetNotificationsTool(client);
+
+    const result = await tool.handler({
+      limit: 30,
+      cursor: 'notifPage',
+      seenAt: '2026-01-15T00:00:00.000Z',
+    });
+
+    expect(listNotifications).toHaveBeenCalledWith({
+      limit: 30,
+      cursor: 'notifPage',
+      seenAt: '2026-01-15T00:00:00.000Z',
+    });
+    // PRIVATE tool -> always authenticated path.
+    expect(client.executeAuthenticatedRequest).toHaveBeenCalled();
+    expect(client.executePublicRequest).not.toHaveBeenCalled();
+
+    expect(result.success).toBe(true);
+    expect(result.cursor).toBe('notifNext');
+    expect(result.hasMore).toBe(true);
+    expect(result.seenAt).toBe('2026-02-01T00:00:00.000Z');
+    expect(result.notifications).toHaveLength(1);
+
+    const [notif] = result.notifications;
+    expect(notif).toEqual({
+      uri: 'at://did:plc:liker/app.bsky.feed.like/abc',
+      cid: 'cidnotif',
+      author: {
+        did: 'did:plc:liker',
+        handle: 'liker.bsky.social',
+        displayName: 'Liker',
+        description: 'fan',
+        avatar: 'https://cdn.example/liker.jpg',
+        followersCount: 10,
+        followsCount: 20,
+        postsCount: 5,
+      },
+      reason: 'like',
+      record: { $type: 'app.bsky.feed.like' },
+      isRead: false,
+      indexedAt: '2026-02-02T00:00:00.000Z',
+      labels: [],
+    });
+  });
+
+  it('applies default limit 50 and reports hasMore=false when no cursor is returned', async () => {
+    const listNotifications = vi.fn().mockResolvedValue({
+      data: { notifications: [], cursor: undefined, seenAt: undefined },
+    });
+    const client = makeClient({ listNotifications });
+    const tool = new GetNotificationsTool(client);
+
+    const result = await tool.handler({});
+
+    expect(listNotifications).toHaveBeenCalledWith({
+      limit: 50,
+      cursor: undefined,
+      seenAt: undefined,
+    });
+    expect(result.hasMore).toBe(false);
+    expect(result.cursor).toBeUndefined();
+    expect(result.notifications).toEqual([]);
+  });
+
+  it('rejects an out-of-range limit before calling the agent (zod validation)', async () => {
+    const listNotifications = vi.fn();
+    const client = makeClient({ listNotifications });
+    const tool = new GetNotificationsTool(client);
+
+    await expect(tool.handler({ limit: 500 })).rejects.toThrow();
+    expect(listNotifications).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/write-tools.test.ts
+++ b/src/__tests__/write-tools.test.ts
@@ -1,0 +1,275 @@
+/**
+ * Unit tests for the post-write tools: CreatePostTool, ReplyToPostTool, and
+ * CreateThreadTool.
+ *
+ * These lock the on-the-wire record shapes the tools send to the AT Protocol
+ * agent (agent.post) and the reply strongRef structure ({uri, cid}) built from
+ * CIDs resolved via com.atproto.repo.getRecord. They are regression guards for:
+ *   - facets being attached only when richtext detection finds them,
+ *   - reply.root / reply.parent being populated with resolved CIDs (not rkeys),
+ *   - langs passthrough,
+ *   - thread posts chaining each subsequent reply.parent to the PREVIOUS post's
+ *     returned uri/cid while reply.root stays pinned to the first post.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { CreatePostTool } from '../tools/implementations/create-post-tool.js';
+import { ReplyToPostTool } from '../tools/implementations/reply-to-post-tool.js';
+import { CreateThreadTool } from '../tools/implementations/create-thread-tool.js';
+import type { AtpClient } from '../utils/atp-client.js';
+
+// CIDs must be >=10 alphanumeric chars to pass validateCID in CreatePostTool's
+// response validation; keep all CIDs that long for consistency across tools.
+const ROOT_CID = 'bafyrootcid01';
+
+// Wrap an operation the way AtpClient.executeAuthenticatedRequest does.
+const wrap = async (op: () => unknown) => {
+  try {
+    return { success: true, data: await op() };
+  } catch (error) {
+    return { success: false, error };
+  }
+};
+
+interface IMockAgentParts {
+  post: ReturnType<typeof vi.fn>;
+  getRecord: ReturnType<typeof vi.fn>;
+}
+
+function createMockAtpClient(): { client: AtpClient } & IMockAgentParts {
+  // Default: agent.post resolves a single valid post ref. Tests that create
+  // multiple posts (threads) override with mockResolvedValueOnce.
+  const post = vi.fn().mockResolvedValue({
+    uri: 'at://did:plc:self/app.bsky.feed.post/created',
+    cid: 'bafycreated01',
+  });
+
+  // getCidFromUri -> com.atproto.repo.getRecord -> { data: { cid } }
+  const getRecord = vi.fn().mockResolvedValue({
+    data: {
+      uri: 'at://did:plc:author/app.bsky.feed.post/parent',
+      cid: ROOT_CID,
+    },
+  });
+
+  const agent = {
+    post,
+    com: { atproto: { repo: { getRecord } } },
+    session: { did: 'did:plc:self' },
+  };
+
+  const client = {
+    getAgent: vi.fn().mockReturnValue(agent),
+    isAuthenticated: vi.fn().mockReturnValue(true),
+    hasCredentials: vi.fn().mockReturnValue(true),
+    executeAuthenticatedRequest: vi.fn().mockImplementation(wrap),
+    executePublicRequest: vi.fn().mockImplementation(wrap),
+  } as unknown as AtpClient;
+
+  return { client, post, getRecord };
+}
+
+describe('CreatePostTool', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('posts a plain-text record with the given text and no facets', async () => {
+    const { client, post, getRecord } = createMockAtpClient();
+    const tool = new CreatePostTool(client);
+
+    const result = await tool.handler({ text: 'hello world' });
+
+    expect(result.success).toBe(true);
+    expect(result.uri).toBe('at://did:plc:self/app.bsky.feed.post/created');
+    expect(result.cid).toBe('bafycreated01');
+
+    expect(post).toHaveBeenCalledTimes(1);
+    const record = post.mock.calls[0]![0];
+    expect(record).toMatchObject({ $type: 'app.bsky.feed.post', text: 'hello world' });
+    // Plain text has no detectable facets, so the field must be absent (not []).
+    expect(record.facets).toBeUndefined();
+    expect(record.reply).toBeUndefined();
+    expect(typeof record.createdAt).toBe('string');
+    // No reply -> no CID resolution.
+    expect(getRecord).not.toHaveBeenCalled();
+  });
+
+  it('attaches a non-empty facets array when the text contains a URL', async () => {
+    const { client, post } = createMockAtpClient();
+    const tool = new CreatePostTool(client);
+
+    await tool.handler({ text: 'see https://example.com' });
+
+    const record = post.mock.calls[0]![0];
+    expect(Array.isArray(record.facets)).toBe(true);
+    expect(record.facets.length).toBeGreaterThan(0);
+    // The detected facet should be the link feature for the URL.
+    const features = record.facets.flatMap((f: any) => f.features);
+    expect(features.some((feat: any) => feat.$type === 'app.bsky.richtext.facet#link')).toBe(true);
+  });
+
+  it('passes langs through to the record', async () => {
+    const { client, post } = createMockAtpClient();
+    const tool = new CreatePostTool(client);
+
+    await tool.handler({ text: 'hola', langs: ['es', 'en-US'] });
+
+    const record = post.mock.calls[0]![0];
+    expect(record.langs).toEqual(['es', 'en-US']);
+  });
+
+  it('builds reply.root and reply.parent strongRefs with CIDs resolved via getRecord', async () => {
+    const { client, post, getRecord } = createMockAtpClient();
+    // Distinct CIDs per resolved URI so we can prove root vs parent mapping.
+    getRecord.mockImplementation(async ({ rkey }: { rkey: string }) => ({
+      data: { cid: rkey === 'rootkey' ? 'bafyrootcid01' : 'bafyparentci1' },
+    }));
+    const tool = new CreatePostTool(client);
+
+    const rootUri = 'at://did:plc:author/app.bsky.feed.post/rootkey';
+    const parentUri = 'at://did:plc:author/app.bsky.feed.post/parentkey';
+
+    await tool.handler({ text: 'a reply', reply: { root: rootUri, parent: parentUri } });
+
+    // Both root and parent CIDs are resolved via getRecord.
+    expect(getRecord).toHaveBeenCalledTimes(2);
+
+    const record = post.mock.calls[0]![0];
+    expect(record.reply).toEqual({
+      root: { uri: rootUri, cid: 'bafyrootcid01' },
+      parent: { uri: parentUri, cid: 'bafyparentci1' },
+    });
+  });
+});
+
+describe('ReplyToPostTool', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('builds reply.root and reply.parent {uri,cid} via getRecord and posts via agent.post', async () => {
+    const { client, post, getRecord } = createMockAtpClient();
+    getRecord.mockImplementation(async ({ rkey }: { rkey: string }) => ({
+      data: { cid: rkey === 'rootkey' ? 'bafyrootcid01' : 'bafyparentci1' },
+    }));
+    const tool = new ReplyToPostTool(client);
+
+    const rootUri = 'at://did:plc:author/app.bsky.feed.post/rootkey';
+    const parentUri = 'at://did:plc:author/app.bsky.feed.post/parentkey';
+
+    const result = await tool.handler({ text: 'replying', root: rootUri, parent: parentUri });
+
+    expect(result.success).toBe(true);
+    expect(result.uri).toBe('at://did:plc:self/app.bsky.feed.post/created');
+    expect(result.replyTo).toEqual({ root: rootUri, parent: parentUri });
+
+    // Resolves a CID for both root and parent.
+    expect(getRecord).toHaveBeenCalledTimes(2);
+
+    // Reply posted through agent.post (not a namespaced creator).
+    expect(post).toHaveBeenCalledTimes(1);
+    const record = post.mock.calls[0]![0];
+    expect(record).toMatchObject({ $type: 'app.bsky.feed.post', text: 'replying' });
+    expect(record.reply).toEqual({
+      root: { uri: rootUri, cid: 'bafyrootcid01' },
+      parent: { uri: parentUri, cid: 'bafyparentci1' },
+    });
+  });
+
+  it('passes langs through on the reply record', async () => {
+    const { client, post } = createMockAtpClient();
+    const tool = new ReplyToPostTool(client);
+
+    await tool.handler({
+      text: 'replying',
+      root: 'at://did:plc:author/app.bsky.feed.post/rootkey',
+      parent: 'at://did:plc:author/app.bsky.feed.post/parentkey',
+      langs: ['en'],
+    });
+
+    const record = post.mock.calls[0]![0];
+    expect(record.langs).toEqual(['en']);
+  });
+});
+
+describe('CreateThreadTool', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('chains posts: root has no reply, each subsequent reply.parent is the previous post and reply.root stays the first post', async () => {
+    const { client, post, getRecord } = createMockAtpClient();
+    // Vary agent.post return per call so we can assert the chain references the
+    // PREVIOUS post's returned uri/cid (not a static value).
+    post
+      .mockResolvedValueOnce({
+        uri: 'at://did:plc:self/app.bsky.feed.post/p1',
+        cid: 'bafycidp0001',
+      })
+      .mockResolvedValueOnce({
+        uri: 'at://did:plc:self/app.bsky.feed.post/p2',
+        cid: 'bafycidp0002',
+      })
+      .mockResolvedValueOnce({
+        uri: 'at://did:plc:self/app.bsky.feed.post/p3',
+        cid: 'bafycidp0003',
+      });
+
+    const tool = new CreateThreadTool(client);
+
+    const result = await tool.handler({
+      posts: [{ text: 'one' }, { text: 'two' }, { text: 'three' }],
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.totalPosts).toBe(3);
+    expect(result.thread).toHaveLength(3);
+    expect(result.rootPost).toEqual({
+      uri: 'at://did:plc:self/app.bsky.feed.post/p1',
+      cid: 'bafycidp0001',
+    });
+
+    expect(post).toHaveBeenCalledTimes(3);
+    // Thread chaining uses the previous post's returned ref, not getRecord.
+    expect(getRecord).not.toHaveBeenCalled();
+
+    const first = post.mock.calls[0]![0];
+    const second = post.mock.calls[1]![0];
+    const third = post.mock.calls[2]![0];
+
+    // Root post carries no reply.
+    expect(first.reply).toBeUndefined();
+    expect(first).toMatchObject({ text: 'one' });
+
+    // Second replies to the first; root + parent both point at post 1.
+    expect(second.reply).toEqual({
+      root: { uri: 'at://did:plc:self/app.bsky.feed.post/p1', cid: 'bafycidp0001' },
+      parent: { uri: 'at://did:plc:self/app.bsky.feed.post/p1', cid: 'bafycidp0001' },
+    });
+
+    // Third's root stays pinned to post 1, parent advances to post 2.
+    expect(third.reply).toEqual({
+      root: { uri: 'at://did:plc:self/app.bsky.feed.post/p1', cid: 'bafycidp0001' },
+      parent: { uri: 'at://did:plc:self/app.bsky.feed.post/p2', cid: 'bafycidp0002' },
+    });
+  });
+
+  it('applies post-specific langs and falls back to thread-wide langs', async () => {
+    const { client, post } = createMockAtpClient();
+    post
+      .mockResolvedValueOnce({
+        uri: 'at://did:plc:self/app.bsky.feed.post/p1',
+        cid: 'bafycidp0001',
+      })
+      .mockResolvedValueOnce({
+        uri: 'at://did:plc:self/app.bsky.feed.post/p2',
+        cid: 'bafycidp0002',
+      });
+
+    const tool = new CreateThreadTool(client);
+
+    await tool.handler({
+      langs: ['en'],
+      posts: [{ text: 'one', langs: ['fr'] }, { text: 'two' }],
+    });
+
+    // Post 1 uses its own langs; post 2 inherits thread-wide langs.
+    expect(post.mock.calls[0]![0].langs).toEqual(['fr']);
+    expect(post.mock.calls[1]![0].langs).toEqual(['en']);
+  });
+});

--- a/src/tools/implementations/__tests__/base-tool.test.ts
+++ b/src/tools/implementations/__tests__/base-tool.test.ts
@@ -183,6 +183,27 @@ describe('BaseTool', () => {
     });
   });
 
+  describe('uploadBlob encoding', () => {
+    it('defaults the encoding when the blob has no MIME type', async () => {
+      const uploadBlob = vi.fn().mockResolvedValue({ data: { blob: { ref: 'x' } } });
+      const client = {
+        isAuthenticated: vi.fn().mockReturnValue(true),
+        hasCredentials: vi.fn().mockReturnValue(true),
+        getAgent: vi.fn().mockReturnValue({ uploadBlob }),
+        executeAuthenticatedRequest: vi
+          .fn()
+          .mockImplementation(async (op: () => unknown) => ({ success: true, data: await op() })),
+      } as unknown as AtpClient;
+      const tool = new TestTool(client);
+      const blob = new Blob(['data'], { type: '' });
+
+      await tool['uploadBlob'](blob);
+
+      // An empty encoding produces an invalid/empty Content-Type; default it.
+      expect(uploadBlob).toHaveBeenCalledWith(blob, { encoding: 'application/octet-stream' });
+    });
+  });
+
   describe('getCidFromUri error propagation', () => {
     it('preserves a typed error (RateLimitError) instead of collapsing it to a generic Error', async () => {
       const rateLimited = {

--- a/src/tools/implementations/base-tool.ts
+++ b/src/tools/implementations/base-tool.ts
@@ -354,12 +354,36 @@ export abstract class BaseTool implements IMcpTool {
     return await this.executeAtpOperation(
       async () => {
         const agent = this.atpClient.getAgent();
-        const response = await agent.uploadBlob(blob, { encoding: blob.type });
+        // A Blob with no type yields an empty encoding (invalid Content-Type);
+        // fall back to a generic binary type so the upload is well-formed.
+        const encoding = blob.type || 'application/octet-stream';
+        const response = await agent.uploadBlob(blob, { encoding });
         return response.data;
       },
       'uploadBlob',
       { blobSize: blob.size, blobType: blob.type }
     );
+  }
+
+  /**
+   * Fetch a single post view (app.bsky.feed.getPosts) for the given AT-URI. The
+   * returned view carries both the post CID and the caller's viewer state
+   * (like/repost), so callers that need both can do it in one round-trip rather
+   * than a separate getRecord + getPosts. Returns undefined if the post is not
+   * found.
+   */
+  protected async getPostView(
+    uri: string
+  ): Promise<{ cid?: string; viewer?: { like?: string; repost?: string } } | undefined> {
+    const response = await this.executeAtpOperation(
+      async () => {
+        const agent = this.atpClient.getAgent();
+        return await agent.getPosts({ uris: [uri] });
+      },
+      'getPosts',
+      { uri }
+    );
+    return response.data.posts[0];
   }
 
   /**

--- a/src/tools/implementations/batch-operations-tools.ts
+++ b/src/tools/implementations/batch-operations-tools.ts
@@ -279,22 +279,22 @@ export class BatchLikeTool extends BaseTool {
           // Validate the URI
           this.validateAtUri(uri);
 
-          // Get the CID for the post
-          const cid = await this.getCidFromUri(uri);
+          // One round-trip: the post view carries both the CID (for the like
+          // subject) and viewer.like (authoritative "already liked" signal).
+          const post = await this.getPostView(uri);
+          if (!post?.cid) {
+            throw new Error(`Post not found or missing CID: ${uri}`);
+          }
 
-          // Check if already liked
-          const existingLike = await this.checkExistingLike(uri, cid);
-          if (existingLike) {
-            this.logger.debug('Post is already liked', {
-              uri,
-              likeUri: existingLike.uri,
-            });
+          const existingLikeUri = post.viewer?.like;
+          if (existingLikeUri) {
+            this.logger.debug('Post is already liked', { uri, likeUri: existingLikeUri });
 
             results.push({
               uri,
               success: true,
-              likeUri: existingLike.uri as ATURI,
-              likeCid: existingLike.cid as CID,
+              likeUri: existingLikeUri as ATURI,
+              likeCid: '' as CID,
               alreadyLiked: true,
             });
 
@@ -308,7 +308,7 @@ export class BatchLikeTool extends BaseTool {
             $type: 'app.bsky.feed.like',
             subject: {
               uri,
-              cid,
+              cid: post.cid,
             },
             createdAt: new Date().toISOString(),
           };
@@ -387,35 +387,7 @@ export class BatchLikeTool extends BaseTool {
     }
   }
 
-  /**
-   * Check if the post is already liked
-   */
-  private async checkExistingLike(
-    postUri: string,
-    _postCid: string
-  ): Promise<{ uri: string; cid: string } | null> {
-    try {
-      // viewer.like is the authoritative "have I liked this post" signal, with
-      // no 100-record scan limit (the old listRecords scan missed likes on
-      // accounts with >100 likes, causing duplicate like records).
-      const response = await this.executeAtpOperation(
-        async () => {
-          const agent = this.atpClient.getAgent();
-          return await agent.getPosts({ uris: [postUri] });
-        },
-        'getPostViewerState',
-        { postUri }
-      );
-
-      const likeUri = response.data.posts[0]?.viewer?.like;
-      return likeUri ? { uri: likeUri, cid: '' } : null;
-    } catch (error) {
-      this.logger.warn('Could not check for existing like', error);
-      return null;
-    }
-  }
-
-  // getCidFromUri is provided by BaseTool.
+  // Post lookup (CID + viewer state) is provided by BaseTool.getPostView.
 }
 
 /**
@@ -485,22 +457,22 @@ export class BatchRepostTool extends BaseTool {
           // Validate the URI
           this.validateAtUri(uri);
 
-          // Get the CID for the post
-          const cid = await this.getCidFromUri(uri);
+          // One round-trip: the post view carries both the CID (for the repost
+          // subject) and viewer.repost (authoritative "already reposted" signal).
+          const post = await this.getPostView(uri);
+          if (!post?.cid) {
+            throw new Error(`Post not found or missing CID: ${uri}`);
+          }
 
-          // Check if already reposted
-          const existingRepost = await this.checkExistingRepost(uri, cid);
-          if (existingRepost) {
-            this.logger.debug('Post is already reposted', {
-              uri,
-              repostUri: existingRepost.uri,
-            });
+          const existingRepostUri = post.viewer?.repost;
+          if (existingRepostUri) {
+            this.logger.debug('Post is already reposted', { uri, repostUri: existingRepostUri });
 
             results.push({
               uri,
               success: true,
-              repostUri: existingRepost.uri as ATURI,
-              repostCid: existingRepost.cid as CID,
+              repostUri: existingRepostUri as ATURI,
+              repostCid: '' as CID,
               alreadyReposted: true,
             });
 
@@ -514,7 +486,7 @@ export class BatchRepostTool extends BaseTool {
             $type: 'app.bsky.feed.repost',
             subject: {
               uri,
-              cid,
+              cid: post.cid,
             },
             createdAt: new Date().toISOString(),
           };
@@ -593,32 +565,5 @@ export class BatchRepostTool extends BaseTool {
     }
   }
 
-  /**
-   * Check if the post is already reposted
-   */
-  private async checkExistingRepost(
-    postUri: string,
-    _postCid: string
-  ): Promise<{ uri: string; cid: string } | null> {
-    try {
-      // viewer.repost is the authoritative "have I reposted this" signal, with
-      // no 100-record scan limit.
-      const response = await this.executeAtpOperation(
-        async () => {
-          const agent = this.atpClient.getAgent();
-          return await agent.getPosts({ uris: [postUri] });
-        },
-        'getPostViewerState',
-        { postUri }
-      );
-
-      const repostUri = response.data.posts[0]?.viewer?.repost;
-      return repostUri ? { uri: repostUri, cid: '' } : null;
-    } catch (error) {
-      this.logger.warn('Could not check for existing repost', error);
-      return null;
-    }
-  }
-
-  // getCidFromUri is provided by BaseTool.
+  // Post lookup (CID + viewer state) is provided by BaseTool.getPostView.
 }

--- a/src/tools/implementations/composite-tools.ts
+++ b/src/tools/implementations/composite-tools.ts
@@ -8,6 +8,33 @@ import type { AtpClient } from '../../utils/atp-client.js';
 import type { IAtpPost, IAtpProfile } from '../../types/index.js';
 
 /**
+ * Map a post view to the internal IAtpPost shape (record passed through as-is).
+ * Shared by the composite tools so they don't each carry an identical copy.
+ */
+function toAtpPost(post: any): IAtpPost {
+  return {
+    uri: post.uri,
+    cid: post.cid,
+    author: {
+      did: post.author.did,
+      handle: post.author.handle,
+      displayName: post.author.displayName,
+      avatar: post.author.avatar,
+      description: post.author.description,
+      followersCount: post.author.followersCount,
+      followsCount: post.author.followsCount,
+      postsCount: post.author.postsCount,
+    },
+    record: post.record,
+    replyCount: post.replyCount,
+    repostCount: post.repostCount,
+    likeCount: post.likeCount,
+    indexedAt: post.indexedAt,
+    ...(post.viewer && { viewer: post.viewer }),
+  };
+}
+
+/**
  * Zod schema for get user summary parameters
  */
 const GetUserSummarySchema = z.object({
@@ -122,7 +149,7 @@ export class GetUserSummaryTool extends BaseTool {
           { actor: params.actor, limit: params.postLimit }
         );
 
-        const posts = feedResponse.data.feed.map((item: any) => this.transformPost(item.post));
+        const posts = feedResponse.data.feed.map((item: any) => toAtpPost(item.post));
 
         if (params.includeRecentPosts) {
           recentPosts = posts;
@@ -180,32 +207,6 @@ export class GetUserSummaryTool extends BaseTool {
       this.logger.error('Failed to get user summary', error);
       this.formatError(error);
     }
-  }
-
-  /**
-   * Transform post data to internal interface
-   */
-  private transformPost(post: any): IAtpPost {
-    return {
-      uri: post.uri,
-      cid: post.cid,
-      author: {
-        did: post.author.did,
-        handle: post.author.handle,
-        displayName: post.author.displayName,
-        avatar: post.author.avatar,
-        description: post.author.description,
-        followersCount: post.author.followersCount,
-        followsCount: post.author.followsCount,
-        postsCount: post.author.postsCount,
-      },
-      record: post.record,
-      replyCount: post.replyCount,
-      repostCount: post.repostCount,
-      likeCount: post.likeCount,
-      indexedAt: post.indexedAt,
-      ...(post.viewer && { viewer: post.viewer }),
-    };
   }
 }
 
@@ -298,21 +299,19 @@ export class GetPostContextTool extends BaseTool {
         throw new Error('Post not found or blocked');
       }
 
-      const post = this.transformPost(threadData.post);
+      const post = toAtpPost(threadData.post);
 
       // Extract thread information
       let thread: any | undefined;
       if (params.includeThread) {
-        const parent = threadData.parent?.post
-          ? this.transformPost(threadData.parent.post)
-          : undefined;
+        const parent = threadData.parent?.post ? toAtpPost(threadData.parent.post) : undefined;
         const root = threadData.parent?.parent?.post
-          ? this.transformPost(threadData.parent.parent.post)
+          ? toAtpPost(threadData.parent.parent.post)
           : parent;
 
         const replies = (threadData.replies || [])
           .filter((r: any) => r.post)
-          .map((r: any) => this.transformPost(r.post));
+          .map((r: any) => toAtpPost(r.post));
 
         thread = {
           parent,
@@ -377,31 +376,5 @@ export class GetPostContextTool extends BaseTool {
       this.logger.error('Failed to get post context', error);
       this.formatError(error);
     }
-  }
-
-  /**
-   * Transform post data to internal interface
-   */
-  private transformPost(post: any): IAtpPost {
-    return {
-      uri: post.uri,
-      cid: post.cid,
-      author: {
-        did: post.author.did,
-        handle: post.author.handle,
-        displayName: post.author.displayName,
-        avatar: post.author.avatar,
-        description: post.author.description,
-        followersCount: post.author.followersCount,
-        followsCount: post.author.followsCount,
-        postsCount: post.author.postsCount,
-      },
-      record: post.record,
-      replyCount: post.replyCount,
-      repostCount: post.repostCount,
-      likeCount: post.likeCount,
-      indexedAt: post.indexedAt,
-      ...(post.viewer && { viewer: post.viewer }),
-    };
   }
 }

--- a/src/utils/__tests__/firehose-lifecycle.test.ts
+++ b/src/utils/__tests__/firehose-lifecycle.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Unit tests for FirehoseClient lifecycle logic.
+ *
+ * These exercise the reconnect/backoff/teardown logic WITHOUT real network or
+ * real timers. The class only opens a WebSocket inside connect(); the lifecycle
+ * helpers under test (scheduleReconnect/teardownSocket/disconnect/getFirehoseUrl)
+ * never touch the socket on their own, so we can drive them via casting and fake
+ * timers. Regression guards for:
+ *  - the error-then-close double-schedule race (guard in scheduleReconnect)
+ *  - the exponential backoff being capped at 30s
+ *  - disconnect() fully tearing down (subscriptions cleared, shutting-down set)
+ *  - teardownSocket() being a no-op when no socket is attached
+ *  - getFirehoseUrl() scheme selection from ATPROTO_RELAY
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { FirehoseClient } from '../firehose-client.js';
+
+const makeClient = (): FirehoseClient =>
+  new FirehoseClient({ service: 'https://bsky.social' } as never);
+
+describe('FirehoseClient lifecycle', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('scheduleReconnect()', () => {
+    it('increments reconnectAttempts and arms a reconnectTimer', () => {
+      const client = makeClient();
+      const c = client as any;
+
+      expect(c.reconnectAttempts).toBe(0);
+      expect(c.reconnectTimer).toBeNull();
+
+      c.scheduleReconnect();
+
+      expect(c.reconnectAttempts).toBe(1);
+      expect(c.reconnectTimer).not.toBeNull();
+    });
+
+    it('does not double-increment while a reconnect timer is already pending', () => {
+      const client = makeClient();
+      const c = client as any;
+
+      // Both the 'close' and 'error' handlers can call scheduleReconnect for one
+      // failed connection; the second call must be a no-op because reconnectTimer
+      // is still set.
+      c.scheduleReconnect();
+      c.scheduleReconnect();
+
+      expect(c.reconnectAttempts).toBe(1);
+    });
+
+    it('does nothing when the client is shutting down', () => {
+      const client = makeClient();
+      const c = client as any;
+      c.isShuttingDown = true;
+
+      c.scheduleReconnect();
+
+      expect(c.reconnectAttempts).toBe(0);
+      expect(c.reconnectTimer).toBeNull();
+    });
+
+    it('bounds the backoff delay at 30000ms even with a high attempt count', () => {
+      const client = makeClient();
+      const c = client as any;
+      const setTimeoutSpy = vi.spyOn(global, 'setTimeout');
+
+      // Force the exponential term well past the cap (2^49 * 1000) and pin
+      // Math.random to its max so jitter pushes the delay to its upper bound.
+      c.reconnectAttempts = 49;
+      const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0.999999);
+
+      c.scheduleReconnect();
+
+      // The reconnect timer is armed by the scheduleReconnect's setTimeout. Find
+      // the call whose delay is the bounded backoff (the only one this method
+      // makes for the reconnect itself).
+      const delays = setTimeoutSpy.mock.calls.map(call => call[1] as number);
+      const maxDelay = Math.max(...delays);
+
+      expect(maxDelay).toBeLessThanOrEqual(30000);
+      // base is capped at 30000, full-jitter floor is base/2, so the upper-bound
+      // jittered delay lands in (15000, 30000].
+      expect(maxDelay).toBeGreaterThan(15000);
+
+      randomSpy.mockRestore();
+    });
+
+    it('keeps the delay within the full-jitter window [base/2, base] for the first attempt', () => {
+      const client = makeClient();
+      const c = client as any;
+      const setTimeoutSpy = vi.spyOn(global, 'setTimeout');
+      // First attempt: base = min(1000 * 2^0, 30000) = 1000, jitter window
+      // [500, 1000].
+      const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0);
+
+      c.scheduleReconnect();
+
+      const delay = setTimeoutSpy.mock.calls.map(call => call[1] as number).find(d => d <= 1000);
+      // random=0 -> delay = round(base/2) = 500 (the floor of the jitter window).
+      expect(delay).toBe(500);
+
+      randomSpy.mockRestore();
+    });
+  });
+
+  describe('disconnect()', () => {
+    it('sets isShuttingDown and clears all subscriptions', async () => {
+      const client = makeClient();
+      const c = client as any;
+
+      client.subscribe({ id: 'sub-a', onEvent: () => {} });
+      client.subscribe({ id: 'sub-b', onEvent: () => {} });
+      expect(client.getSubscriptionCount()).toBe(2);
+
+      await client.disconnect();
+
+      expect(c.isShuttingDown).toBe(true);
+      expect(client.getSubscriptionCount()).toBe(0);
+    });
+  });
+
+  describe('teardownSocket()', () => {
+    it('is a no-op (does not throw) when no socket is attached', () => {
+      const client = makeClient();
+      const c = client as any;
+
+      expect(c.ws).toBeNull();
+      expect(() => c.teardownSocket()).not.toThrow();
+      expect(c.ws).toBeNull();
+    });
+  });
+
+  describe('getFirehoseUrl()', () => {
+    const originalRelay = process.env['ATPROTO_RELAY'];
+
+    afterEach(() => {
+      if (originalRelay === undefined) {
+        delete process.env['ATPROTO_RELAY'];
+      } else {
+        process.env['ATPROTO_RELAY'] = originalRelay;
+      }
+    });
+
+    it('defaults to the wss public relay subscribeRepos endpoint', () => {
+      delete process.env['ATPROTO_RELAY'];
+      const c = makeClient() as any;
+
+      expect(c.getFirehoseUrl()).toBe('wss://bsky.network/xrpc/com.atproto.sync.subscribeRepos');
+    });
+
+    it('preserves an explicit ws:// scheme for local relays', () => {
+      process.env['ATPROTO_RELAY'] = 'ws://localhost:6008';
+      const c = makeClient() as any;
+
+      expect(c.getFirehoseUrl()).toBe('ws://localhost:6008/xrpc/com.atproto.sync.subscribeRepos');
+    });
+
+    it('maps https:// and bare hosts to secure wss://', () => {
+      process.env['ATPROTO_RELAY'] = 'https://relay.example.com';
+      const c = makeClient() as any;
+
+      expect(c.getFirehoseUrl()).toBe(
+        'wss://relay.example.com/xrpc/com.atproto.sync.subscribeRepos'
+      );
+    });
+
+    it('appends a cursor from lastSeq so the reconnect resumes the stream', () => {
+      delete process.env['ATPROTO_RELAY'];
+      const c = makeClient() as any;
+      c.lastSeq = 12345;
+
+      expect(c.getFirehoseUrl()).toBe(
+        'wss://bsky.network/xrpc/com.atproto.sync.subscribeRepos?cursor=12345'
+      );
+    });
+  });
+});

--- a/src/utils/__tests__/logger.test.ts
+++ b/src/utils/__tests__/logger.test.ts
@@ -32,4 +32,20 @@ describe('Logger stdio safety', () => {
     expect(logSpy).not.toHaveBeenCalled();
     expect(errSpy).toHaveBeenCalledTimes(1);
   });
+
+  it('strips control chars from a logged stack trace but preserves newlines', () => {
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    const err = new Error('boom');
+    // An attacker-influenced error message is echoed in the stack's first line;
+    // a raw CR or other control char there would let it forge extra log lines.
+    err.stack = 'Error: boom\r\n\x07INJECTED fake line\n  at someFn (file.ts:1:1)';
+    new Logger('Test').error('failed', err);
+
+    const output = errSpy.mock.calls.map(call => String(call[0])).join('\n');
+    expect(output).not.toContain('\r');
+    expect(output).not.toContain('\x07');
+    // The genuine stack newlines (frames) are kept for readability.
+    expect(output).toContain('\n  at someFn (file.ts:1:1)');
+  });
 });

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -97,6 +97,18 @@ export class Logger {
   }
 
   /**
+   * Sanitize a multi-line stack trace for logging. Unlike single-line fields, a
+   * stack legitimately spans multiple lines, so newlines and tabs are kept while
+   * other control chars (incl. CR) are stripped — the stack's first line echoes
+   * the (attacker-influenceable) error message, so a raw CR/control char there
+   * could otherwise forge extra log lines.
+   */
+  private sanitizeStack(stack: string): string {
+    // eslint-disable-next-line no-control-regex
+    return stack.replace(/\r/g, '').replace(/[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]/g, '');
+  }
+
+  /**
    * Format log entry for output
    */
   private formatLogEntry(entry: ILogEntry): string {
@@ -116,7 +128,7 @@ export class Logger {
     if (entry.error) {
       formatted += `\n  Error: ${this.sanitizeForLog(entry.error.message)}`;
       if (entry.error.stack) {
-        formatted += `\n  Stack: ${entry.error.stack}`;
+        formatted += `\n  Stack: ${this.sanitizeStack(entry.error.stack)}`;
       }
     }
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -29,10 +29,10 @@ export default defineConfig({
       // actually fails the run. Values are a no-regression ratchet pinned just
       // under current real coverage; raise them as coverage improves.
       thresholds: {
-        branches: 34,
-        functions: 56,
-        lines: 47,
-        statements: 47,
+        branches: 44,
+        functions: 67,
+        lines: 59,
+        statements: 59,
       },
     },
     setupFiles: ['./src/test/setup.ts'],


### PR DESCRIPTION
Follow-up to the merged end-to-end review (#22). Picks up the remaining threads: backfill the test coverage that was the #1 structural risk, finish the deferred dedup, and address the remaining low-severity findings — all test-driven.

## Test coverage backfill
Adds unit tests for the highest-risk previously-untested surfaces and ratchets the coverage floor to match (the gate is a no-regression ratchet pinned just under real coverage):

| metric | before | now (floor) |
|---|---|---|
| statements | 47 | **59** |
| lines | 47 | **59** |
| functions | 56 | **67** |
| branches | 34 | **44** |

Suite: **383 passing** (was 330). New files:
- **moderation-tools** — mute/block subject DID resolution, unblock URI→rkey parsing, report content/user subject shapes + exact `reasonType` NSIDs, `analyze_moderation_status` running unauthenticated.
- **media-tools** — image MIME from extension + blob encoding, path-traversal refusal, rich-text facet mapping, alt-text guidance, media extraction.
- **write-tools** — `create_post` facets/langs/reply-ref CID resolution, `reply_to_post` strongRefs, `create_thread` parent/root chaining.
- **firehose-lifecycle** — reconnect backoff bound + double-increment guard, disconnect teardown, `getFirehoseUrl` scheme/cursor handling (fake timers).
- **social-graph** — pagination cursor/limit passthrough and result mapping.
- **batch-roundtrip** — `batch_like`/`batch_repost` reuse the `getPosts` CID.

## Code changes (each test-driven)
- **logger** — strip control chars from logged stack traces (keep newlines) so an attacker-influenced error message can't forge extra log lines.
- **BaseTool.uploadBlob** — default encoding to `application/octet-stream` when a Blob has no type (avoids an empty/invalid Content-Type).
- **batch_like / batch_repost** — fetch each post once via the new `BaseTool.getPostView` (CID + viewer state), removing the redundant per-item `getRecord` round-trip (halves per-item network calls).
- **composite-tools** — hoist the two identical `transformPost` copies into one shared helper.

## Deliberately NOT changed (with rationale)
- **ErrorSanitizer keyword list** — kept conservative; loosening it trades safety for friendlier messages, not a clear win.
- **mid-request 401 retry** — `executeRequest` does not blindly retry on a 401; that would risk double-executing non-idempotent writes, and the agent already refreshes tokens internally.
- **ConversationContextResource static state** — stdio MCP is one client per process (process-global == per-client), and the write API is intentionally dormant; instance state would mean threading the resource through every tool for a multi-client transport that doesn't exist.

Local `npm run check` (lint + format:check + type-check + test) is green.