### PR TITLE
Review fixes (batch 2): validate create_rich_text_post facets

### DIFF
--- a/src/__tests__/rich-text-facets.test.ts
+++ b/src/__tests__/rich-text-facets.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Regression test: create_rich_text_post must validate caller-supplied facets.
+ * Byte offsets that exceed the text's UTF-8 length produce mis-aligned (or
+ * server-rejected) facets, and a mention must reference a DID — a bare handle
+ * yields an invalid mention facet, so handles are resolved to DIDs.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { CreateRichTextPostTool } from '../tools/implementations/media-tools.js';
+import { ValidationError } from '../types/index.js';
+import type { AtpClient } from '../utils/atp-client.js';
+
+function mockClient() {
+  const post = vi
+    .fn()
+    .mockResolvedValue({ uri: 'at://did:plc:self/app.bsky.feed.post/x', cid: 'bafyreiabc' });
+  const resolveHandle = vi.fn().mockResolvedValue({ data: { did: 'did:plc:bob' } });
+  const agent = {
+    post,
+    com: { atproto: { identity: { resolveHandle } } },
+    session: { did: 'did:plc:self' },
+  };
+  const client = {
+    getAgent: vi.fn().mockReturnValue(agent),
+    isAuthenticated: vi.fn().mockReturnValue(true),
+    hasCredentials: vi.fn().mockReturnValue(true),
+    executeAuthenticatedRequest: vi.fn().mockImplementation(async (op: () => unknown) => {
+      try {
+        return { success: true, data: await op() };
+      } catch (error) {
+        return { success: false, error };
+      }
+    }),
+  } as unknown as AtpClient;
+  return { client, post, resolveHandle };
+}
+
+describe('create_rich_text_post facet validation', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('rejects a facet whose byteEnd exceeds the text byte length', async () => {
+    const { client, post } = mockClient();
+    const tool = new CreateRichTextPostTool(client);
+
+    await expect(
+      tool.handler({
+        text: 'hello', // 5 bytes
+        facets: [
+          {
+            index: { byteStart: 0, byteEnd: 99 },
+            features: [{ type: 'link', value: 'https://x.com' }],
+          },
+        ],
+      })
+    ).rejects.toBeInstanceOf(ValidationError);
+    expect(post).not.toHaveBeenCalled();
+  });
+
+  it('rejects a facet whose byteStart is not before byteEnd', async () => {
+    const { client, post } = mockClient();
+    const tool = new CreateRichTextPostTool(client);
+
+    await expect(
+      tool.handler({
+        text: 'hello',
+        facets: [
+          {
+            index: { byteStart: 3, byteEnd: 3 },
+            features: [{ type: 'link', value: 'https://x.com' }],
+          },
+        ],
+      })
+    ).rejects.toBeInstanceOf(ValidationError);
+    expect(post).not.toHaveBeenCalled();
+  });
+
+  it('resolves a mention handle to a DID in the facet record', async () => {
+    const { client, post, resolveHandle } = mockClient();
+    const tool = new CreateRichTextPostTool(client);
+
+    await tool.handler({
+      text: 'hi @bob',
+      facets: [
+        { index: { byteStart: 3, byteEnd: 7 }, features: [{ type: 'mention', value: 'bob.test' }] },
+      ],
+    });
+
+    expect(resolveHandle).toHaveBeenCalledWith({ handle: 'bob.test' });
+    const record = post.mock.calls[0][0] as {
+      facets: Array<{ features: Array<{ did?: string }> }>;
+    };
+    expect(record.facets[0].features[0].did).toBe('did:plc:bob');
+  });
+});

--- a/src/tools/implementations/media-tools.ts
+++ b/src/tools/implementations/media-tools.ts
@@ -5,6 +5,7 @@
 import { z } from 'zod';
 import { BaseTool } from './base-tool.js';
 import type { AtpClient } from '../../utils/atp-client.js';
+import { ValidationError } from '../../types/index.js';
 import { readFile } from 'fs/promises';
 import { extname } from 'path';
 import { assertSafePath, safeFetch } from '../../utils/url-safety.js';
@@ -401,32 +402,45 @@ export class CreateRichTextPostTool extends BaseTool {
         createdAt: new Date().toISOString(),
       };
 
-      // Add facets if provided
+      // Add facets if provided. Caller-supplied facets are UNTRUSTED: validate the
+      // byte range against the text's UTF-8 length (a bad range silently links the
+      // wrong substring or is rejected by the PDS), and resolve mention handles to
+      // DIDs (a mention facet must carry a DID, not a handle).
       if (params.facets && params.facets.length > 0) {
-        postRecord.facets = params.facets.map(facet => ({
-          index: facet.index,
-          features: facet.features.map(feature => {
+        const textByteLength = Buffer.byteLength(params.text, 'utf8');
+        const builtFacets = [];
+        for (const facet of params.facets) {
+          const { byteStart, byteEnd } = facet.index;
+          if (byteStart >= byteEnd || byteEnd > textByteLength) {
+            throw new ValidationError(
+              `Invalid facet byte range [${byteStart}, ${byteEnd}); must satisfy ` +
+                `byteStart < byteEnd <= ${textByteLength} (the text's UTF-8 byte length).`,
+              'facets'
+            );
+          }
+          const features = [];
+          for (const feature of facet.features) {
             switch (feature.type) {
-              case 'mention':
-                return {
-                  $type: 'app.bsky.richtext.facet#mention',
-                  did: feature.value,
-                };
+              case 'mention': {
+                const did = feature.value.startsWith('did:')
+                  ? feature.value
+                  : await this.resolveDid(feature.value);
+                features.push({ $type: 'app.bsky.richtext.facet#mention', did });
+                break;
+              }
               case 'link':
-                return {
-                  $type: 'app.bsky.richtext.facet#link',
-                  uri: feature.value,
-                };
+                features.push({ $type: 'app.bsky.richtext.facet#link', uri: feature.value });
+                break;
               case 'hashtag':
-                return {
-                  $type: 'app.bsky.richtext.facet#tag',
-                  tag: feature.value,
-                };
+                features.push({ $type: 'app.bsky.richtext.facet#tag', tag: feature.value });
+                break;
               default:
-                return feature;
+                features.push(feature);
             }
-          }),
-        }));
+          }
+          builtFacets.push({ index: facet.index, features });
+        }
+        postRecord.facets = builtFacets;
       }
 
       // Add embed if provided. Image/thumbnail blobs MUST be real uploaded


### PR DESCRIPTION
Follow-up to #24. Validates caller-supplied facets in `create_rich_text_post`: rejects byte ranges outside the text's UTF-8 length (which silently mis-link substrings or get rejected by the PDS) and resolves mention handles to DIDs (a mention facet must carry a DID). TDD'd; full suite green (410 tests), type-check + lint clean.